### PR TITLE
fix(daemon): wire --to through TaskDelegate + clearer trust-filtered errors

### DIFF
--- a/crates/logos-messaging-a2a-cli/src/agent.rs
+++ b/crates/logos-messaging-a2a-cli/src/agent.rs
@@ -154,6 +154,7 @@ pub async fn handle(
             exec,
         } => {
             let caps = parse_capabilities(&capabilities);
+            let trust_file_explicit = trust_file.is_some();
             let trust_path =
                 trust_file.unwrap_or_else(logos_messaging_a2a_core::TrustList::default_path);
             let trust_list = logos_messaging_a2a_core::TrustList::load_from(&trust_path)
@@ -217,6 +218,27 @@ pub async fn handle(
                     "Trust: {trust_mode:?} ({trust_count} entries from {})",
                     trust_path.display()
                 );
+                // Loud warning when an *implicit* default trust file is
+                // active in Enforce mode — incoming presence + delegation
+                // from peers not on the list will be silently filtered,
+                // and operators have been bitten by stale lists from a
+                // previous demo carrying over into a fresh run.
+                if !trust_file_explicit
+                    && matches!(
+                        trust_mode,
+                        logos_messaging_a2a_core::TrustMode::Enforce
+                    )
+                    && trust_count > 0
+                {
+                    eprintln!(
+                        "warning: trust list is in `enforce` mode with {trust_count} entries \
+                         loaded from the default path ({}). Peers not on the list will be \
+                         filtered out of presence and delegation. Pass `--trust-file <path>` \
+                         to use a different list, or run `lmao trust mode off` to disable \
+                         filtering for this identity.",
+                        trust_path.display()
+                    );
+                }
                 if identity.encrypt {
                     if let Some(ref bundle) = node.card.intro_bundle {
                         println!("Encryption: ENABLED (X25519+ChaCha20-Poly1305)");

--- a/crates/logos-messaging-a2a-cli/src/daemon/server.rs
+++ b/crates/logos-messaging-a2a-cli/src/daemon/server.rs
@@ -226,7 +226,24 @@ impl DaemonServer {
                     timeout_secs,
                     session_id,
                 };
-                let results = if broadcast {
+                // `--to <pubkey>` short-circuits strategy selection: send
+                // the subtask directly to the named peer, regardless of
+                // capability list / load / round-robin counter. Trust
+                // list still applies — direct delegation to an untrusted
+                // peer surfaces a diagnostic error rather than silently
+                // failing strategy fall-through (the previous behaviour
+                // dropped `to` on the floor and ran FirstAvailable).
+                let results = if let Some(ref pk) = to {
+                    if broadcast {
+                        return Ok(Response::Error {
+                            message:
+                                "--broadcast cannot be combined with --to (direct delegation \
+                                 targets a single peer)"
+                                    .into(),
+                        });
+                    }
+                    vec![self.node.delegate_direct(&request, pk).await?]
+                } else if broadcast {
                     self.node.delegate_broadcast(&request).await?
                 } else {
                     vec![self.node.delegate_task(&request).await?]
@@ -439,9 +456,10 @@ fn build_strategy(
     capability: Option<&str>,
     strategy_name: Option<&str>,
 ) -> DelegationStrategy {
-    if let Some(_pk) = to {
-        // Direct delegation goes through `to` on the request — the
-        // strategy field is unused. Use FirstAvailable as a no-op.
+    if to.is_some() {
+        // Direct delegation is dispatched separately (see `delegate_direct`
+        // call site). The strategy field on the request is unused in that
+        // path; we still return *some* value here to satisfy the type.
         return DelegationStrategy::FirstAvailable;
     }
     match strategy_name {

--- a/crates/logos-messaging-a2a-node/src/delegation.rs
+++ b/crates/logos-messaging-a2a-node/src/delegation.rs
@@ -3,7 +3,7 @@
 
 use logos_messaging_a2a_core::{
     topics, A2AEnvelope, DelegationRequest, DelegationResult, DelegationStrategy, LoadBucket, Task,
-    TaskState,
+    TaskState, TrustMode,
 };
 use logos_messaging_a2a_transport::Transport;
 use std::sync::atomic::Ordering;
@@ -30,6 +30,31 @@ fn load_rank(info: &PeerInfo) -> u8 {
     }
 }
 
+/// Build a delegation error that distinguishes "no candidates exist" from
+/// "candidates exist but trust filtered them all out". The second case is
+/// confusing in practice — operators see "no live peers" while
+/// `presence peers` shows live peers — so name it explicitly.
+fn no_trusted_peers_err<T: Transport>(
+    node: &LmaoNode<T>,
+    total_candidates: usize,
+    capability: Option<&str>,
+) -> NodeError {
+    let mode = node.trust_mode();
+    let what = match capability {
+        Some(cap) => format!("with capability '{cap}'"),
+        None => String::from("available"),
+    };
+    if total_candidates > 0 && !matches!(mode, TrustMode::Off) {
+        NodeError::Other(format!(
+            "no trusted peers {what} for delegation: {total_candidates} live peer(s) all filtered \
+             by trust list (mode={mode:?}). Add them with `lmao trust add <pubkey>` or pass \
+             `--trust-file <path>` to use a different list."
+        ))
+    } else {
+        NodeError::Other(format!("no live peers {what} for delegation"))
+    }
+}
+
 impl<T: Transport> LmaoNode<T> {
     /// Delegate a subtask to a single peer based on the delegation strategy.
     ///
@@ -53,26 +78,22 @@ impl<T: Transport> LmaoNode<T> {
             DelegationStrategy::FirstAvailable => {
                 let mut peers = self.peers().all_live();
                 peers.sort_by_key(|(_, info)| load_rank(info));
+                let total_live = peers.len();
                 peers
                     .into_iter()
                     .map(|(id, _)| id)
                     .find(|id| self.is_trusted(id))
-                    .ok_or_else(|| {
-                        NodeError::Other("no live peers available for delegation".into())
-                    })?
+                    .ok_or_else(|| no_trusted_peers_err(self, total_live, None))?
             }
             DelegationStrategy::CapabilityMatch { capability } => {
                 let mut peers = self.find_peers_by_capability(capability);
                 peers.sort_by_key(|(_, info)| load_rank(info));
+                let total_live = peers.len();
                 peers
                     .into_iter()
                     .map(|(id, _)| id)
                     .find(|id| self.is_trusted_for(id, capability))
-                    .ok_or_else(|| {
-                        NodeError::Other(format!(
-                            "no live peers with capability '{capability}' for delegation"
-                        ))
-                    })?
+                    .ok_or_else(|| no_trusted_peers_err(self, total_live, Some(capability)))?
             }
             DelegationStrategy::BroadcastCollect => {
                 // For single delegation, broadcast acts like first-available
@@ -113,6 +134,36 @@ impl<T: Transport> LmaoNode<T> {
 
         Metrics::inc(&self.metrics.delegations_sent);
         self.delegate_to_peer(request, &peer_id, timeout_secs).await
+    }
+
+    /// Delegate a subtask directly to a specific peer by pubkey, bypassing
+    /// strategy-based selection. Used when the caller already knows which
+    /// peer should handle the task (e.g. `lmao task delegate --to <pk>`
+    /// through the daemon, or any UI that has a peer handle).
+    ///
+    /// Honors the trust list — direct delegation still respects the
+    /// configured `TrustMode`. In `Off` mode this is a no-op; in `Log` /
+    /// `Enforce` an untrusted target produces a diagnostic error rather
+    /// than silently falling back to strategy-based routing.
+    pub async fn delegate_direct(
+        &self,
+        request: &DelegationRequest,
+        peer_pubkey: &str,
+    ) -> Result<DelegationResult> {
+        let timeout_secs = if request.timeout_secs == 0 {
+            DEFAULT_DELEGATION_TIMEOUT_SECS
+        } else {
+            request.timeout_secs
+        };
+        if !self.is_trusted(peer_pubkey) {
+            return Err(NodeError::Other(format!(
+                "direct delegation to {peer_pubkey} blocked: peer not on trust list (mode={:?}). \
+                 Add it with `lmao trust add` or pass an alternate `--trust-file`.",
+                self.trust_mode()
+            )));
+        }
+        Metrics::inc(&self.metrics.delegations_sent);
+        self.delegate_to_peer(request, peer_pubkey, timeout_secs).await
     }
 
     /// Delegate a subtask to all matching peers and collect responses.

--- a/crates/logos-messaging-a2a-node/tests/trust_filter.rs
+++ b/crates/logos-messaging-a2a-node/tests/trust_filter.rs
@@ -314,7 +314,7 @@ async fn delegate_errors_when_no_trusted_peer_advertises_capability() {
     let err = alice.delegate_task(&req).await.unwrap_err();
     let msg = format!("{err}");
     assert!(
-        msg.contains("no live peers with capability"),
-        "expected capability-not-found error, got: {msg}"
+        msg.contains("with capability 'code'") && msg.contains("trust list"),
+        "expected trust-filtered capability error, got: {msg}"
     );
 }


### PR DESCRIPTION
## Summary

Two demo-time pitfalls fixed:

1. **`task delegate --to <pubkey>` was a no-op through the daemon.** The `to` flag was silently dropped — the daemon ran `FirstAvailable` strategy instead, which scans the live peer map filtered by trust. With even a single entry in an `Enforce`-mode trust list, direct delegation surfaced as `no live peers available for delegation` while `presence peers` showed the target fine. New `LmaoNode::delegate_direct` bypasses strategy and dispatches straight to `delegate_to_peer`. The daemon's `TaskDelegate` handler picks `delegate_direct` when `to` is set, falls through to strategy when it isn't, and rejects the nonsensical `--to` + `--broadcast` combo.

2. **Strategy errors now distinguish "no peers exist" from "all peers were trust-filtered".** Old text was an unconditional `no live peers …`. With trust filtering, the message now reads `no trusted peers … for delegation: N live peer(s) all filtered by trust list (mode=Enforce). Add them with 'lmao trust add <pubkey>' or pass '--trust-file <path>'`. This is what made the original bug invisible — peer was visible in `presence peers`, gone in `delegate`.

3. **Trust list inherited from a prior session.** `agent run` without `--trust-file` reads `~/.config/lmao/trust.toml`. If the operator had set up a peer-restricted Enforce list during an earlier demo, every fresh agent silently inherited it. Now logs a stderr warning at startup when the implicit default is loaded in Enforce mode with non-zero entries, with `--trust-file <path>` and `lmao trust mode off` as escape hatches.

## Test plan

- [x] `cargo test --workspace` — all green (one trust-filter assertion updated to match the more diagnostic error string)
- [x] Live two-agent smoke against the public Logos Dev fleet: `task delegate --to <pubkey>` through the daemon now returns the executor's response (previously errored with `no live peers available`)
- [x] Capability-routed delegation continues to work
- [x] `presence peers` still shows trust-filtered peers (read path unchanged — only the delegation routing path was wrong)

🤖 Generated with [Claude Code](https://claude.com/claude-code)