### PR TITLE
chore(gitignore): cover all Nix result-* outputs and personal slides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,8 @@ dist/
 # `git add -A` doesn't accidentally commit secrets.
 /demo-config/pi/agent/models.json
 /demo-config/pi/agent/auth.json
+
+# Personal presentation material — kept out of the repo by default.
+# Drop this entry if you want to publish slides alongside the code.
+/slides/
+/SLIDES_CONTEXT.md

--- a/basecamp/.gitignore
+++ b/basecamp/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
-result
+# Catches `result`, `result-portable`, `result-fat`, `result-mcp`, etc. —
+# every Nix output flavour `nix build -o <name>` may produce.
+result*
 build/
 .direnv
-result

--- a/basecamp/agent-ui/.gitignore
+++ b/basecamp/agent-ui/.gitignore
@@ -1,3 +1,3 @@
 .DS_Store
-result
+result*
 build/


### PR DESCRIPTION
## Summary

- `basecamp/.gitignore` had only `result` (plus a duplicate). `nix build -o result-fat` and `-o result-portable` outputs were leaking into `git status`. Switched to `result*` so every Nix output flavour is covered going forward without per-name enumeration.
- Same fix mirrored in `basecamp/agent-ui/.gitignore` for parity.
- Root `.gitignore` adds `/slides/` and `/SLIDES_CONTEXT.md` for personal presentation material kept on the host but not part of the codebase. Comment notes the entry can be dropped if you ever want to publish slides alongside the code.

## Test plan

- [x] `git check-ignore -v basecamp/agent-module/result-fat basecamp/agent-module/result-portable slides/ SLIDES_CONTEXT.md` — all four matched
- [x] `git status` after the change — only the three .gitignore files shown, untracked artefacts gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)