### PR TITLE
fix(basecamp/agent-module): trust_add dispatch + daemon-error response shape

### DIFF
--- a/basecamp/agent-module/src/agent_impl.cpp
+++ b/basecamp/agent-module/src/agent_impl.cpp
@@ -522,7 +522,21 @@ std::string AgentImpl::start_delegate(const std::string& capability,
         QJsonDocument doc = QJsonDocument::fromJson(resp.toUtf8());
         if (doc.isObject()) {
             QJsonObject obj = doc.object();
-            if (obj.contains("error")) {
+            // Daemon serializes Response::Error as
+            //   {"kind": "error", "message": "<text>"}
+            // (see crates/.../daemon/protocol.rs — `#[serde(tag = "kind",
+            // rename_all = "snake_case")]`). The earlier code looked for
+            // a top-level `error` key that the daemon never emits, so
+            // every daemon-side failure (no live peers, trust filtered,
+            // delegation timed out before a single tick of the strategy
+            // selector) collapsed to a misleading "no matching peer
+            // responded". Match the actual shape, AND keep the legacy
+            // `error` key as a fallback for any older daemon someone
+            // might still be talking to.
+            if (obj.value("kind").toString() == "error" && obj.contains("message")) {
+                event["success"] = false;
+                event["error"]   = obj["message"];
+            } else if (obj.contains("error")) {
                 event["success"] = false;
                 event["error"]   = obj["error"];
             } else {
@@ -591,7 +605,13 @@ std::string AgentImpl::start_fetch_cid(const std::string& cid) {
         QJsonDocument doc = QJsonDocument::fromJson(resp.toUtf8());
         if (doc.isObject()) {
             QJsonObject obj = doc.object();
-            if (obj.contains("error")) {
+            // Same daemon-error shape as start_delegate above:
+            // `{kind: "error", message}` is the wire format, but legacy
+            // code checked the wrong key. Surface the real message.
+            if (obj.value("kind").toString() == "error" && obj.contains("message")) {
+                event["success"] = false;
+                event["error"]   = obj["message"];
+            } else if (obj.contains("error")) {
                 event["success"] = false;
                 event["error"]   = obj["error"];
             } else {

--- a/basecamp/agent-module/src/agent_impl.h
+++ b/basecamp/agent-module/src/agent_impl.h
@@ -110,10 +110,10 @@ public:
     /// Add (or replace) a trusted peer. `capabilities` is a comma-
     /// separated list — empty string means "trusted for any capability".
     /// `notes` may be empty. Returns the JSON daemon response.
-    std::string trust_add(const std::string& pubkey,
-                          const std::string& nickname,
-                          const std::string& capabilities,
-                          const std::string& notes);
+    /// (Single-line signature — the universal-module C++ parser
+    /// silently skips multi-line method declarations, which is how
+    /// this method shipped without a dispatch wrapper for two builds.)
+    std::string trust_add(const std::string& pubkey, const std::string& nickname, const std::string& capabilities, const std::string& notes);
 
     /// Remove a trusted peer by pubkey *or* nickname.
     std::string trust_remove(const std::string& target);


### PR DESCRIPTION
## Summary

Two bugs that bit a live demo when adding a peer to the trust list via the QML Trust pane and then trying to delegate to that peer.

### 1. `unknown method: "trust_add"`

The universal-module C++ generator parses `agent_impl.h` line-by-line and **silently drops any method whose declaration spans multiple lines**. `task_history_list` already had a "(Single-line signature — the universal-module C++ parser silently skips multi-line method declarations.)" comment warning about this. `trust_add` is a 4-arg method that was wrapped onto four lines, so the generator never emitted a dispatch wrapper for it. `nm -D agent_plugin.so | c++filt | grep AgentProviderObject` confirms: the wrappers for `trust_remove` and `trust_mode` are present, `trust_add` is missing.

Result: the QML Trust pane's "Add" button has been a no-op since the trust feature shipped — the IPC layer sees `unknown method` and silently fails. Collapse the declaration to one line; carry the warning comment forward so future devs don't trip on it again.

### 2. Spurious `no matching peer responded` masking real daemon errors

`start_delegate` and `start_fetch_cid` parse the IPC reply by looking for a top-level `error` key. The daemon emits `Response::Error` as `{"kind": "error", "message": "<text>"}` per `protocol.rs:95`'s `#[serde(tag = "kind", rename_all = "snake_case")]` — there is no top-level `error` key, ever. So every daemon-side failure (`no live peers`, trust-filtered with the new diagnostic message from #12, delegation timed out before a tick of the strategy selector, etc.) collapsed to the misleading `no matching peer responded` / null `payload_b64` branches.

Match the real `{"kind": "error", "message": ...}` shape; keep the legacy `error` lookup as a fallback for older daemons.

## Test plan

- [x] `nm -D agent_plugin.so | c++filt | grep trust_add` finds a wrapper symbol after rebuild (verified that today's installed .so doesn't have one)
- [ ] After rebuild + reinstall via `scripts/build-fat-lgx.sh`: QML Trust pane → Add → daemon's trust list grows; subsequent delegation surfaces the real daemon error message rather than a generic "no matching peer responded"

## Roll-out

Source-only fix — need to rebuild the LGX (`scripts/build-fat-lgx.sh`) and reinstall before it takes effect inside Basecamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)