### PR TITLE
feat(demo-config/pi): max-turns extension for tool-call rounds

### DIFF
--- a/demo-config/pi/agent/extensions/max-turns.ts
+++ b/demo-config/pi/agent/extensions/max-turns.ts
@@ -1,0 +1,48 @@
+// Bound the number of tool-call rounds pi will perform per task.
+//
+// pi-coding-agent has no built-in max-turns / max-iterations knob; the
+// only first-class limit on a delegated task is the wall-clock
+// `PI_TIMEOUT` we apply in `scripts/pi-exec.sh`. That's blunt — a model
+// stuck in a tool loop happily burns the full budget and reports a
+// timeout failure with nothing useful to show for it.
+//
+// This extension intercepts the `tool_call` event and, after
+// `PI_MAX_TURNS` calls (default 8), blocks every subsequent one with a
+// reason string the model receives back. The model then has to wrap up
+// with an answer based on what it already has, or hit the wall-clock
+// timeout if it really refuses.
+//
+// pi runs as a fresh `--print` subprocess per delegated task (see
+// pi-exec.sh), so the module-scope counter resets implicitly between
+// tasks. The session_start handler also resets it for safety in case
+// the same instance ever drives multiple sessions (interactive use,
+// `/new`, `/resume`).
+//
+// Mount this file into the container at
+// `/home/lmao/.pi/agent/extensions/max-turns.ts` — pi auto-discovers
+// any `.ts` under that path.
+
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+const MAX_TURNS = Number(process.env.PI_MAX_TURNS ?? 8);
+
+let count = 0;
+
+export default function (pi: ExtensionAPI) {
+    pi.on("session_start", async () => {
+        count = 0;
+    });
+
+    pi.on("tool_call", async () => {
+        count += 1;
+        if (count > MAX_TURNS) {
+            return {
+                block: true,
+                reason:
+                    `max turns (${MAX_TURNS}) reached for this task. ` +
+                    `Stop calling tools and answer the user with what you ` +
+                    `have so far.`,
+            };
+        }
+    });
+}


### PR DESCRIPTION
## Summary

`pi-coding-agent` has no built-in max-turns / max-iterations knob. The only first-class limit on a delegated task is the wall-clock `PI_TIMEOUT` we apply in `scripts/pi-exec.sh` — fine as a hard ceiling, useless as a soft cap. A model stuck in a tool-call loop happily burns the full budget and reports a timeout failure with nothing useful to show for it, when what we usually want is "do at most N turns of tool use, then answer with what you have."

Drops in a tiny pi extension at `demo-config/pi/agent/extensions/max-turns.ts` that hooks `tool_call` and, after `PI_MAX_TURNS` rounds (default 8), returns `{ block: true, reason }` on every subsequent call. The model receives the block reason and has to wrap up.

Combined with `PI_TIMEOUT` you get both cost-bounded and time-bounded execution; either is enough to abort, both run together for safety.

## How to use

The example compose in `RUNNING_REMOTE.md` already mounts `./pi-config:/home/lmao/.pi:ro` and pi auto-discovers `.ts` extensions under `~/.pi/agent/extensions/`. So:

```bash
mkdir -p pi-config/agent/extensions
cp demo-config/pi/agent/extensions/max-turns.ts pi-config/agent/extensions/
podman compose up -d   # restart picks up the extension
```

Optionally bump the default in your compose:

```yaml
environment:
  PI_MAX_TURNS: "12"
```

## Test plan

- [x] Validated the `tool_call` event signature and `{ block, reason }` return shape against pi's bundled `extensions.md`
- [x] Confirmed pi runs as a fresh `--print` subprocess per delegated task (see `scripts/pi-exec.sh`), so the module-scope counter resets implicitly
- [ ] (when next testing remotely) Send a delegation that would normally tool-loop; confirm pi cuts off at the configured `PI_MAX_TURNS` and answers with what it has

🤖 Generated with [Claude Code](https://claude.com/claude-code)