### PR TITLE
refactor(agent-module): API surface freeze — Client vs Operator + MODULE_API.md

### DIFF
--- a/basecamp/agent-module/src/agent_impl.h
+++ b/basecamp/agent-module/src/agent_impl.h
@@ -15,24 +15,58 @@
 /// owns the actual Logos Messaging node + libstorage; this class is
 /// the C++ ↔ JSON bridge.
 ///
-/// Methods come in two flavours:
+/// # Public API contract
 ///
-/// - Synchronous (`info`, `peers`, `daemon_state`, `trust_*`, …) —
-///   block on a fast IPC round-trip (~10 ms). Use for queries the UI
-///   needs to render this frame.
-/// - Asynchronous (`start_delegate`, `start_fetch_cid`) — return a
-///   request_id immediately, run the actual IPC on a worker thread,
-///   then call `emitEvent("<name>_complete", json)` with a payload
-///   keyed by that request_id. Use for anything that can take more
-///   than a frame (LLM inference, Codex DHT walks).
+/// The methods below are split into two intended-audience groups:
 ///
-/// Returned strings are JSON unless otherwise noted; on error the
-/// returned JSON is shaped `{"error": "<message>"}` so callers can
-/// branch on `.error`.
+/// - **Client API** — the subset other Basecamp modules and UIs are
+///   expected to depend on. Stable: changes need a version bump and
+///   migration notes. Documented in detail in `docs/MODULE_API.md`.
+///   Use case: a Notes app calling `agent.start_delegate("summarize",
+///   note_text, "")` to summarise a note via any peer that advertises
+///   the `summarize` capability.
+/// - **Operator API** — used by an agent's own settings/admin UI
+///   (currently the QML Trust pane in `basecamp/agent-ui`). Not part
+///   of the public contract; semantics may shift as the trust list and
+///   daemon-lifecycle surfaces evolve.
 ///
-/// API constraints (per Logos universal-module rules): only
-/// `std::string`, `bool`, `int64_t`, `uint64_t`, `double`, `void`,
-/// `std::vector<T>`. No Qt types in this header.
+/// # Method flavours
+///
+/// - **Synchronous** (`info`, `peers`, `daemon_state`, `trust_*`,
+///   `task_history_*`) — block on a fast IPC round-trip (~10 ms). Use
+///   for queries the UI needs to render this frame.
+/// - **Asynchronous** (`start_delegate`, `start_fetch_cid`) — return a
+///   request_id JSON ack immediately; the actual IPC runs on a worker
+///   thread; on completion fire `emitEvent("<name>_complete", json)`
+///   keyed by that id. Use for anything that can take more than a
+///   frame (LLM inference, Codex DHT walks). **Recommended over the
+///   synchronous variants when calling from a UI thread.**
+///
+/// # Return shapes
+///
+/// All methods return JSON-encoded `std::string`. Two error shapes a
+/// caller must handle:
+///
+/// - From this module's own validation (e.g. daemon not running):
+///   `{"error": "<message>"}`. Branch on `.error`.
+/// - Forwarded from the daemon process:
+///   `{"kind": "error", "message": "<text>"}`. Branch on
+///   `kind == "error" && message`.
+///
+/// Successful responses are documented per-method in
+/// `docs/MODULE_API.md`. The `delegate_complete` and
+/// `fetch_cid_complete` event payloads are documented there too.
+///
+/// # Universal-module type constraints
+///
+/// Per Logos universal-module rules, only `std::string`, `bool`,
+/// `int64_t`, `uint64_t`, `double`, `void`, `std::vector<T>`. No Qt
+/// types in this header.
+///
+/// **Method declarations must be single-line.** The C++ generator
+/// silently skips multi-line declarations — `trust_add` shipped
+/// without a dispatch wrapper for two builds because of this. If you
+/// edit this header, keep every method on one line.
 class AgentImpl {
 public:
     AgentImpl();
@@ -41,78 +75,92 @@ public:
     AgentImpl(const AgentImpl&) = delete;
     AgentImpl& operator=(const AgentImpl&) = delete;
 
-    /// Daemon identity, uptime, configuration.
+    // ── Client API ──────────────────────────────────────────────────
+    //
+    // Stable surface for other Basecamp modules + UIs to depend on.
+    // See docs/MODULE_API.md for the full contract.
+
+    /// Daemon identity, uptime, configuration. Synchronous.
+    /// Returns `{name, pubkey, capabilities, encryption_pubkey?,
+    /// storage_spr?, load, uptime_secs, …}`.
     std::string info();
 
-    /// Live peers in the daemon's PeerMap. Pass an empty string to
-    /// list all live peers; pass a capability (e.g. `"code"`) to filter.
-    std::string peers(const std::string& capability_filter);
-
-    /// Delegate a task by capability — finds a matching peer, sends
-    /// the task, waits for the response.
-    std::string delegate(const std::string& capability, const std::string& text);
-
-    /// Async delegate. Returns a JSON ack with a `task_id` immediately;
-    /// the actual IPC runs on a worker thread. On completion fires
-    /// `emitEvent("delegate_complete", json)` where `json` carries:
-    ///   { task_id, success, agent_id, body, cid, error, elapsed_ms }
-    /// The QML side starts the call, then listens via
-    /// `Connections { target: logos; function onModuleEventReceived(...) }`
-    /// to render results without blocking the UI thread.
-    /// `session_id` (empty string = none) threads the conversation: when
-    /// set, the receiver's exec gets `LMAO_SESSION_ID=<id>` so wrappers
-    /// (pi --session, lemonade conversation history) can reuse a thread
-    /// instead of cold-starting on every follow-up.
-    /// (Single-line signature — the universal-module C++ parser
-    /// silently skips multi-line method declarations.)
-    std::string start_delegate(const std::string& capability, const std::string& text, const std::string& session_id);
-
-    /// Send a task directly to a known recipient pubkey.
-    std::string send_task(const std::string& recipient_pubkey, const std::string& text);
-
-    /// Fetch bytes by CID from the embedded libstorage backend. The
-    /// payload is base64-encoded in the JSON response since IPC
-    /// carries arbitrary binary.
-    std::string fetch_cid(const std::string& cid);
-
-    /// Async fetch. Returns a JSON ack with a `request_id` immediately;
-    /// runs on a worker thread. On completion fires
-    /// `emitEvent("fetch_cid_complete", json)`:
-    ///   { request_id, cid, success, payload_b64, error }
-    /// Used for the auto-prefetch on delegation success and any CID
-    /// click in the UI — the QML thread never blocks on the Codex
-    /// DHT walk.
-    std::string start_fetch_cid(const std::string& cid);
-
-    /// Ask the running daemon to stop and exit cleanly.
-    std::string stop_daemon();
-
-    /// Whether the subprocess is currently running and its IPC socket
-    /// is reachable.
-    bool is_running();
-
     /// Local liveness probe — no IPC round-trip. Returns one of:
-    ///   - `"ready"`    daemon socket has appeared and the agent is
-    ///                  accepting IPC.
-    ///   - `"starting"` subprocess spawned, still dialing the mesh /
-    ///                  binding the socket. Typically lasts 10-20 s
-    ///                  on a cold start.
-    ///   - `"offline"`  subprocess never started or exited.
-    /// Used by the QML status timer to render a tri-state badge
-    /// without paying the IPC cost while the daemon is still booting.
+    /// `"ready"` (daemon socket up, accepting IPC),
+    /// `"starting"` (subprocess spawned, still dialing the mesh / binding
+    /// the socket — typically 10–20 s on a cold start),
+    /// `"offline"` (subprocess never started or exited).
+    /// Use this before calling other methods so the UI can render a
+    /// non-blocking "starting…" state.
     std::string daemon_state();
 
-    /// Snapshot the daemon's friend-keyring trust list. Returns the
-    /// JSON daemon response: `{kind: "trust_list", mode, entries: […],
-    /// trust_file?}`.
+    /// Live peers in the daemon's PeerMap. Pass an empty string to
+    /// list all live peers; pass a capability (e.g. `"code"`) to
+    /// filter. Returns a JSON array of peer entries.
+    std::string peers(const std::string& capability_filter);
+
+    /// Async delegate by capability — finds a matching peer, sends
+    /// the subtask, listens for the response. Returns immediately with
+    /// `{task_id, session_id}`; on completion fires
+    /// `emitEvent("delegate_complete", json)` carrying
+    /// `{task_id, success, agent_id, body, cid, error, elapsed_ms}`.
+    /// `session_id` (empty string = stamp a fresh one) threads the
+    /// conversation across follow-up turns: receivers see it as
+    /// `LMAO_SESSION_ID` so executor wrappers (pi `--session`,
+    /// lemonade conversation history) can reuse a thread instead of
+    /// cold-starting every turn. **Recommended entry point** —
+    /// non-blocking, event-driven, plays nicely with QML.
+    std::string start_delegate(const std::string& capability, const std::string& text, const std::string& session_id);
+
+    /// Synchronous delegate by capability. Blocks the caller for up to
+    /// the configured timeout (`LMAO_AGENT_DELEGATE_TIMEOUT_SECS`,
+    /// default 180 s). Use only from a worker thread; prefer
+    /// `start_delegate` from a UI thread.
+    std::string delegate(const std::string& capability, const std::string& text);
+
+    /// Send a task directly to a known recipient pubkey, fire-and-forget.
+    /// Returns `{task_id, acked}` once the recipient ACKs the envelope
+    /// (no executor result is waited for — that arrives via the same
+    /// `delegate_complete` event channel if the receiver responds).
+    std::string send_task(const std::string& recipient_pubkey, const std::string& text);
+
+    /// Async fetch a CID from the storage backend. Returns immediately
+    /// with `{request_id, cid}`; on completion fires
+    /// `emitEvent("fetch_cid_complete", json)` carrying
+    /// `{request_id, cid, success, payload_b64, error}`. **Recommended
+    /// entry point** for any CID-resolution UI affordance — the Codex
+    /// DHT walk can take tens of seconds.
+    std::string start_fetch_cid(const std::string& cid);
+
+    /// Synchronous fetch — blocks for up to 90 s. Returns
+    /// `{cid, payload_b64}` on success; the standard error shapes on
+    /// failure. Prefer `start_fetch_cid` from a UI thread.
+    std::string fetch_cid(const std::string& cid);
+
+    /// List persisted task history (newest first). Pass empty strings
+    /// for `direction` and `capability` to skip those filters. `limit`
+    /// caps the page size; `offset` skips entries before applying the
+    /// cap (pagination). Returns
+    /// `{kind: "task_history_list", entries: [...], history_path?}`.
+    std::string task_history_list(int64_t limit, int64_t offset, const std::string& direction, const std::string& capability);
+
+    /// Look up a single persisted task by id. Returns
+    /// `{kind: "task_history_get", entry?: {...}}`. `entry` is `null`
+    /// when no row matches.
+    std::string task_history_get(const std::string& task_id);
+
+    // ── Operator API ────────────────────────────────────────────────
+    //
+    // Used by an agent's own admin/settings UI. Not part of the
+    // contract other modules consume. Subject to change.
+
+    /// Snapshot the daemon's friend-keyring trust list. Returns
+    /// `{kind: "trust_list", mode, entries: [...], trust_file?}`.
     std::string trust_list();
 
     /// Add (or replace) a trusted peer. `capabilities` is a comma-
     /// separated list — empty string means "trusted for any capability".
-    /// `notes` may be empty. Returns the JSON daemon response.
-    /// (Single-line signature — the universal-module C++ parser
-    /// silently skips multi-line method declarations, which is how
-    /// this method shipped without a dispatch wrapper for two builds.)
+    /// `notes` may be empty.
     std::string trust_add(const std::string& pubkey, const std::string& nickname, const std::string& capabilities, const std::string& notes);
 
     /// Remove a trusted peer by pubkey *or* nickname.
@@ -123,24 +171,23 @@ public:
     /// `"log"`.
     std::string trust_mode(const std::string& new_mode);
 
-    /// List persisted task history (newest first). Pass empty strings
-    /// for `direction` and `capability` to skip those filters. `limit`
-    /// caps the page size; `offset` skips entries before applying the
-    /// cap (useful for pagination). Returns the daemon JSON shape:
-    /// `{kind: "task_history_list", entries: [...], history_path?}`.
-    /// (Single-line signature — the universal-module C++ parser
-    /// silently skips multi-line method declarations.)
-    std::string task_history_list(int64_t limit, int64_t offset, const std::string& direction, const std::string& capability);
+    /// Ask the running daemon to stop and exit cleanly. Returns once
+    /// the daemon socket is gone.
+    std::string stop_daemon();
 
-    /// Look up a single persisted task by id. Returns
-    /// `{kind: "task_history_get", entry?: {...}}` — the entry is
-    /// `null` if no row matches.
-    std::string task_history_get(const std::string& task_id);
+    /// Whether the subprocess is currently running and its IPC socket
+    /// is reachable. Lower-level than `daemon_state()` — that one is
+    /// what UIs should call.
+    bool is_running();
 
-    /// Event emission callback — wired up by the universal-module
-    /// generator at construction time so it can dispatch to the
-    /// LogosProviderBase event channel. Don't call directly; use the
-    /// `start_*` async methods which call it on completion.
+    // ── Generator hookup ───────────────────────────────────────────
+    //
+    // Wired by the universal-module generator's `awk` patch (see
+    // `basecamp/agent-module/flake.nix`). Workers call this from
+    // background threads; the patched ctor marshals onto the GUI
+    // thread via `QMetaObject::invokeMethod(...,
+    // Qt::QueuedConnection)` before forwarding to
+    // LogosProviderBase::emitEvent.
     std::function<void(const std::string& eventName,
                        const std::string& data)> emitEvent;
 

--- a/docs/MODULE_API.md
+++ b/docs/MODULE_API.md
@@ -1,0 +1,341 @@
+# Agent module — public API
+
+The agent module is loadable into Logos Basecamp (and any future
+Logos-core host) as a regular module. Other modules and UIs depend
+on it via `LogosAPI::callModule("agent", method, args)` from C++ /
+`logos.callModule("agent", method, args)` from QML.
+
+This document is the contract. Methods listed here are part of the
+**Client API** — the surface other modules code against. Method
+signatures are stable; behaviour changes need a version bump.
+
+The implementation header is `basecamp/agent-module/src/agent_impl.h`.
+That file additionally lists an **Operator API** (`trust_*`,
+`stop_daemon`, `is_running`) used only by an agent's own
+admin/settings UI. Other modules should not depend on those.
+
+## Use case
+
+A Notes app inside Basecamp wants to summarise a note, turn it into
+a travel report, draft a code review, etc. — using whichever peer on
+the user's mesh advertises the matching capability.
+
+```qml
+// In the Notes app's QML, on a "Summarise" menu action:
+const ackRaw = logos.callModule("agent", "start_delegate",
+    [/* capability */ "summarize",
+     /* text       */ note.body,
+     /* session_id */ ""]);
+const ack = JSON.parse(ackRaw);
+if (ack.error) {
+    // surface the failure
+    return;
+}
+// ack: { task_id, session_id }
+// Listen for completion:
+Connections {
+    target: logos
+    function onModuleEventReceived(moduleName, eventName, data) {
+        if (moduleName !== "agent" || eventName !== "delegate_complete") return;
+        const event = JSON.parse(data[0]);
+        if (event.task_id !== ack.task_id) return;
+        if (!event.success) {
+            // event.error has the reason
+            return;
+        }
+        appendSummaryToNote(note, event.body);
+        if (event.cid) saveAuditLogCid(note, event.cid);
+    }
+}
+```
+
+The agent module routes the task by capability, picks a trusted live
+peer, ships the text, waits for the response, fires the
+`delegate_complete` event back to the Notes app.
+
+## Method conventions
+
+- All methods return JSON-encoded `std::string`.
+- All methods are reachable via `logos.callModule(...)` / `getClient(...)`.
+- **Async methods** (`start_*`) return immediately with an ack
+  containing a request id (`task_id` for delegations, `request_id`
+  for fetches); the actual result arrives later as a named event
+  carrying that id. **Prefer these from a UI thread.**
+- **Sync methods** block on a fast IPC round-trip (~10 ms for
+  metadata, longer for `delegate` / `fetch_cid` because they wait
+  on network).
+
+### Error shapes
+
+A consumer must handle two error shapes:
+
+```jsonc
+// (1) Validation error from the agent module itself —
+//     daemon not running, malformed args, etc.
+{ "error": "daemon not running" }
+
+// (2) Forwarded error from the underlying daemon process —
+//     network failure, no live peers, capability mismatch,
+//     trust filter blocked the target, …
+{ "kind": "error", "message": "no trusted peers with capability 'summarize' for delegation: 1 live peer(s) all filtered by trust list (mode=Enforce). Add them with `lmao trust add <pubkey>` or pass `--trust-file <path>` to use a different list." }
+```
+
+A defensive parser:
+
+```js
+function readAgentError(obj) {
+    if (!obj) return "unparseable response";
+    if (obj.error) return obj.error;
+    if (obj.kind === "error" && obj.message) return obj.message;
+    return null;  // not an error
+}
+```
+
+## Methods (Client API)
+
+### `info()`
+
+Daemon identity, uptime, current configuration. Synchronous.
+
+**Args**: none.
+
+**Returns**:
+
+```jsonc
+{
+  "name": "alice",
+  "pubkey": "0226e882fbb0efd6...",
+  "capabilities": ["text", "summarize"],
+  "encryption_pubkey": "cd9de6e0d7bba572...",   // optional — present when --encrypt is enabled
+  "storage_spr": "spr:CiUIAhIh...",            // optional — present when storage is enabled
+  "load": { "bucket": "free", "queue_depth": 0, "max_concurrent": 1, "avg_latency_ms": 0 },
+  "uptime_secs": 2079,
+  "socket_path": "/run/user/1000/lmao-basecamp-685661.sock"
+}
+```
+
+### `daemon_state()`
+
+Local liveness probe — no IPC round-trip. Tri-state badge for UIs.
+
+**Args**: none.
+
+**Returns**: a JSON-encoded string, one of:
+
+- `"ready"` — daemon socket up, accepting IPC.
+- `"starting"` — subprocess spawned, still dialing the mesh / binding the
+  socket. Typically 10–20 s on a cold start.
+- `"offline"` — subprocess never started, or has exited.
+
+> Note: some Basecamp builds JSON-encode `std::string` returns again
+> on the wire. If your `JSON.parse` yields a string instead of a
+> parsed object, re-parse it. See the `parseModuleJson` helper in
+> `basecamp/agent-ui/Main.qml` for a portable pattern.
+
+### `peers(capability_filter)`
+
+Snapshot of the daemon's PeerMap.
+
+**Args**:
+
+| Name | Type | Meaning |
+|---|---|---|
+| `capability_filter` | `string` | Empty = list all live peers. Non-empty (e.g. `"code"`) = only peers advertising that capability. |
+
+**Returns**:
+
+```jsonc
+{
+  "kind": "presence_peers",
+  "peers": [
+    {
+      "agent_id": "02b6a180a38e5dfe...",
+      "name": "bob",
+      "capabilities": ["code", "review"],
+      "waku_topic": "/lmao/1/task-02b6a180a38e5dfe.../proto",
+      "last_seen_secs": 1778310987,
+      "ttl_secs": 300,
+      "load": { "bucket": "free", "queue_depth": 0, "max_concurrent": 1, "avg_latency_ms": 0 }
+    }
+  ]
+}
+```
+
+### `start_delegate(capability, text, session_id)`
+
+Async delegate by capability. **Recommended entry point** for
+delegation from any UI thread.
+
+**Args**:
+
+| Name | Type | Meaning |
+|---|---|---|
+| `capability` | `string` | e.g. `"summarize"`. The agent module routes to a peer that advertises this. |
+| `text` | `string` | Subtask text — the prompt or input passed to the receiver's executor on stdin. |
+| `session_id` | `string` | Empty = stamp a fresh session. Non-empty = continue an existing conversation thread (Follow-up). |
+
+**Returns** (synchronous ack):
+
+```jsonc
+{ "task_id": "fcc907c9-a371-...", "session_id": "<echoed-or-stamped>" }
+```
+
+**Emits** when the delegation finishes (via `emitEvent`):
+
+```jsonc
+// Event name: "delegate_complete"
+// data[0]:
+{
+  "task_id": "fcc907c9-a371-...",      // matches the ack's task_id
+  "success": true,
+  "agent_id": "02b6a180a38e5dfe...",   // peer that handled it
+  "body": "Concise three-sentence summary…",
+  "cid": "zDvZRwzm6E2hZoge2PnJC1RWZ9o…", // when storage is enabled
+  "error": "",                          // populated when success == false
+  "elapsed_ms": 4320
+}
+```
+
+The QML side wires this with `Connections { target: logos; function onModuleEventReceived(moduleName, eventName, data) {…} }` and routes by `task_id`.
+
+### `delegate(capability, text)`
+
+Synchronous delegate. Blocks the caller for up to
+`LMAO_AGENT_DELEGATE_TIMEOUT_SECS` (default 180 s). Use only from
+worker threads.
+
+**Returns** the same shape as the `delegate_complete` event payload
+(without the `task_id`).
+
+### `send_task(recipient_pubkey, text)`
+
+Direct fire-and-forget send to a specific peer.
+
+**Args**:
+
+| Name | Type | Meaning |
+|---|---|---|
+| `recipient_pubkey` | `string` | secp256k1 compressed-hex pubkey, as appears in `peers` / `info`. |
+| `text` | `string` | Task text. |
+
+**Returns**:
+
+```jsonc
+{ "kind": "task_send", "task_id": "c38a0b28-...", "from": "<my-pubkey>", "acked": true }
+```
+
+`acked` is `true` once the recipient acknowledges the envelope
+(SDS layer); the executor result, if any, arrives later via the same
+`delegate_complete` event channel.
+
+### `start_fetch_cid(cid)`
+
+Async fetch of a content-addressed payload from the storage backend.
+**Recommended** for any CID-resolution UI — Codex DHT walks can take
+tens of seconds.
+
+**Args**:
+
+| Name | Type | Meaning |
+|---|---|---|
+| `cid` | `string` | The CID. Strip any `codex://` prefix before calling. |
+
+**Returns** (synchronous ack):
+
+```jsonc
+{ "request_id": "abc123", "cid": "zDvZRwzm6E2hZ..." }
+```
+
+**Emits**:
+
+```jsonc
+// Event name: "fetch_cid_complete"
+// data[0]:
+{
+  "request_id": "abc123",
+  "cid": "zDvZRwzm6E2hZ...",
+  "success": true,
+  "payload_b64": "Y29udGVudHM=",   // base64-encoded bytes
+  "error": ""
+}
+```
+
+### `fetch_cid(cid)`
+
+Synchronous fetch — blocks for up to 90 s. Returns
+`{cid, payload_b64}` on success.
+
+### `task_history_list(limit, offset, direction, capability)`
+
+Page through persisted task history (newest first).
+
+**Args**:
+
+| Name | Type | Meaning |
+|---|---|---|
+| `limit` | `int64` | Max rows to return. |
+| `offset` | `int64` | Rows to skip before the page. |
+| `direction` | `string` | `""` = both, `"sent"` = delegations from us, `"received"` = tasks others sent us. |
+| `capability` | `string` | `""` = no filter, otherwise restrict to that capability. |
+
+**Returns**:
+
+```jsonc
+{
+  "kind": "task_history_list",
+  "entries": [
+    {
+      "task_id": "fcc907c9-...",
+      "direction": "sent",
+      "peer_pubkey": "02b6a180a38e5dfe...",
+      "peer_name": "bob",
+      "capability": "summarize",
+      "text": "<original task text>",
+      "body": "<response>",
+      "cid": "zDv...",
+      "success": true,
+      "error": "",
+      "started_at_secs": 1778310987,
+      "elapsed_ms": 4320,
+      "session_id": "..."
+    }
+  ],
+  "history_path": "/.../history.jsonl"
+}
+```
+
+### `task_history_get(task_id)`
+
+One persisted task by id.
+
+**Returns**: `{kind: "task_history_get", entry: {…} | null}` with the
+same `entry` shape as in `task_history_list`.
+
+## Events emitted
+
+| Event name | Carries | Payload shape |
+|---|---|---|
+| `delegate_complete` | result of a `start_delegate` call | see above |
+| `fetch_cid_complete` | result of a `start_fetch_cid` call | see above |
+
+Consumers must subscribe explicitly:
+
+```qml
+Component.onCompleted: {
+    logos.onModuleEvent("agent", "delegate_complete");
+    logos.onModuleEvent("agent", "fetch_cid_complete");
+}
+```
+
+…before the events flow. Without the explicit subscribe the QML bridge
+filters them out.
+
+## Stability
+
+This document tracks the contract. Method names + argument shapes are
+stable; new fields may be added to return / event payloads (consumers
+should ignore unknown keys). Breaking changes get a major version bump
+in `basecamp/agent-module/metadata.json` and a migration note here.
+
+The Operator API methods listed in `agent_impl.h` (`trust_*`,
+`stop_daemon`, `is_running`) are explicitly NOT part of this contract.


### PR DESCRIPTION
First step of the refactor tracked in #19. **No behaviour changes** — this PR locks down the public API contract so subsequent migration PRs (storage → `storage_module`, messaging → `delivery_module`, identity → `accounts_module`, runtime → `logoscore` Remote) all code against a stable shape.

## Changes

### `agent_impl.h` — grouped by intended audience

Methods are now split into two clearly-labelled groups in the header:

- **Client API** — what other Basecamp modules and UIs depend on. Stable surface; signatures byte-identical to master. Members: `info`, `daemon_state`, `peers`, `start_delegate` / `delegate`, `send_task`, `start_fetch_cid` / `fetch_cid`, `task_history_list`, `task_history_get`.
- **Operator API** — admin/settings UI for the agent itself; *not* part of the contract other modules consume. Members: `trust_*`, `stop_daemon`, `is_running`.

The file-level doc comment now also:

- Names the two error shapes a caller must handle: this module's own validation `{"error": "<message>"}` AND the daemon-forwarded `{"kind": "error", "message": "<text>"}` shape (fixed in #15).
- Reiterates the "every method declaration must be on one line" gotcha that bit `trust_add` for two builds.

`git diff` on the header is comments + reordering only — no signature changed.

### `docs/MODULE_API.md` — the public contract

Documents the Client API methods with:

- The driving use case (Notes app calling `agent.start_delegate("summarize", note_text, "")`, listening for `delegate_complete`, rendering the body + audit-log CID).
- Per-method args + return shape with concrete JSON examples.
- Async vs synchronous variants and which to prefer from a UI thread.
- The two error shapes with a defensive parser snippet.
- Event payloads (`delegate_complete`, `fetch_cid_complete`) and the `logos.onModuleEvent` subscribe step they require.
- Stability promise: method names + argument shapes don't break without a metadata version bump; new fields may be added to return / event payloads (consumers ignore unknowns).

## Risk

Zero functional risk — no `.cpp` changes, no signature changes, no build flags. The header diff is comment + ordering. Only thing that could go wrong is the universal-module C++ generator regressing on the reordering, but every method stays on a single line and the parser scans top-to-bottom — same parse outcome.

## Test plan

- [x] Method count unchanged (15) and signatures byte-identical (`git diff master -- basecamp/agent-module/src/agent_impl.h | grep -E "^[-+]    std::string"` shows only reorderings).
- [ ] After merge: rebuild the LGX (`scripts/build-fat-lgx.sh`), confirm `nm -D agent_plugin.so | c++filt | grep AgentProviderObject::` lists the same wrapper symbols as before this PR.

Refs: #19