### PR TITLE
refactor(workspace): logos-core-bindings — Rust↔LogosAPI in production

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ dependencies = [
  "proptest",
  "rand 0.8.5",
  "ruint",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "serde",
  "sha3",
  "tiny-keccak",
@@ -477,6 +477,26 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bindgen"
+version = "0.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
@@ -490,7 +510,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "shlex",
  "syn 2.0.117",
 ]
@@ -778,6 +798,15 @@ name = "clap_lex"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "colorchoice"
@@ -2101,6 +2130,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "logos-core-bindings"
+version = "0.1.0"
+dependencies = [
+ "bindgen 0.70.1",
+ "cmake",
+ "serde_json",
+]
+
+[[package]]
 name = "logos-messaging-a2a"
 version = "0.1.0"
 dependencies = [
@@ -2761,7 +2799,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustls",
  "socket2",
  "thiserror",
@@ -2781,7 +2819,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.2",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -3147,6 +3185,12 @@ name = "ruint-macro"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -3615,7 +3659,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c860b5a3b9c2ab7b32f752a13c92051740b9a18b441edfca2b491a32eb02440"
 dependencies = [
- "bindgen",
+ "bindgen 0.72.1",
  "bytesize",
  "cc",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,10 @@ members = [
     "crates/lmao-ffi",
     "crates/logos-messaging-a2a-ffi",
     "crates/logos-messaging-a2a-execution",
+    # Bindings to the Logos C++ SDK via a C-callable shim. build.rs falls
+    # back to stub bindings when LOGOS_CPP_SDK_DIR is unset, so workspace
+    # builds on hosts without Qt6 + the SDK still pass `cargo check`.
+    "crates/logos-core-bindings",
 ]
 # The demo enables the `logos-core` feature which requires liblogos_core.so at
 # link time. Excluding it from the workspace prevents feature unification from

--- a/crates/logos-core-bindings/Cargo.toml
+++ b/crates/logos-core-bindings/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "logos-core-bindings"
+version = "0.1.0"
+edition = "2021"
+description = "Rust bindings to the Logos C++ SDK's LogosAPI, via a C-callable shim."
+publish = false
+
+# The shim links Qt6 + the Logos C++ SDK static lib + Boost + OpenSSL. We
+# don't want the workspace's default `cargo build --workspace` to require
+# all of that. build.rs checks for the `LOGOS_CPP_SDK_DIR` env var:
+#
+# - **Present**: real build — cmake + bindgen + link of `liblogos_shim.a`
+#   + `liblogos_sdk.a`. The crate's `Shim` API works.
+# - **Absent**: stub build — `Shim::new` returns an error explaining how
+#   to enable the real build. The crate compiles, links, and `cargo
+#   check --workspace` passes on a machine without Qt installed.
+#
+# build.rs emits `cargo:rustc-cfg=logos_core_real` in the real-build
+# case so lib.rs can pick which implementation to compile.
+
+[lib]
+name = "logos_core_bindings"
+
+[dependencies]
+serde_json = "1"
+
+[build-dependencies]
+cmake = "0.1"
+bindgen = "0.70"

--- a/crates/logos-core-bindings/README.md
+++ b/crates/logos-core-bindings/README.md
@@ -1,0 +1,78 @@
+# logos-core-bindings
+
+Rust bindings to the Logos C++ SDK's `LogosAPI`, via a C-callable shim.
+The shim owns a Qt event-loop thread and a `LogosAPI` instance; calls
+from any Rust thread are dispatched onto it via QtRO. JSON in / JSON
+out across the FFI — the Rust crate never sees a Qt type.
+
+This is the foundation crate for the refactor tracked in
+[issue #19](https://github.com/vpavlin/lmao/issues/19). Storage,
+messaging, and runtime migrations layer on top.
+
+## Two build modes
+
+The crate compiles in either of two modes, picked by `build.rs` based
+on the `LOGOS_CPP_SDK_DIR` env var:
+
+| Mode    | Trigger                                  | What works                                |
+|---------|------------------------------------------|-------------------------------------------|
+| Real    | `LOGOS_CPP_SDK_DIR` points at a checkout | Full `Shim::new` / `Shim::call`           |
+| Stub    | env var unset                            | Crate compiles; `Shim::new` returns `Error::NotCompiledIn` |
+
+`cargo build --workspace` on a CI host without Qt6 / Boost / OpenSSL /
+the SDK installed picks the stub mode and the workspace stays green.
+Set `LOGOS_CPP_SDK_DIR` to enable the real build.
+
+## Real build prerequisites
+
+- Qt6 — `Core`, `Network`, `RemoteObjects`
+- Boost.System
+- OpenSSL
+- nlohmann_json (header-only)
+- cmake + ninja (or make)
+- bindgen + libclang
+
+The shim is consumed via `cmake-rs` from `build.rs`. Build dir layout
+mirrors the experiment under
+`experiments/rust-logos-api/rust-shim/` — see that README for run
+procedure + gotchas.
+
+## Smoke check
+
+```bash
+# Stub build (CI default):
+cargo check -p logos-core-bindings
+
+# Real build:
+LOGOS_CPP_SDK_DIR=/path/to/logos-cpp-sdk cargo build -p logos-core-bindings
+```
+
+## Usage
+
+```rust
+use logos_core_bindings::Shim;
+
+let shim = Shim::new("my_consumer")?;          // boots Qt thread + LogosAPI
+let json = shim.call(
+    "agent",        // target module name
+    "info",         // method
+    "[]",           // args (JSON array)
+    5_000,          // timeout_ms
+)?;
+println!("{json}");
+```
+
+`Shim` is `Send + Sync` — share via `Arc<Mutex<Shim>>` if multiple
+callers need it. Each `call` is synchronous from the Rust side; the
+Qt thread serialises the underlying `invokeRemoteMethod` invocations.
+Wrap calls in `tokio::task::spawn_blocking` if you're in an async
+runtime.
+
+## Stop here, see also
+
+- [`experiments/rust-logos-api/`](../../experiments/rust-logos-api/)
+  — the original scaffold, including a working `lmao-observatory` TUI
+  that polls the shim. Move that to its own crate once the refactor
+  graduates from `experiments/`.
+- [issue #19](https://github.com/vpavlin/lmao/issues/19) — the full
+  roll-out plan this crate is the first step of.

--- a/crates/logos-core-bindings/build.rs
+++ b/crates/logos-core-bindings/build.rs
@@ -1,0 +1,71 @@
+// Two-mode build:
+//
+// - **`LOGOS_CPP_SDK_DIR` set** → real build. cmake + bindgen against
+//   the shim, link the static archives. Emits `cargo:rustc-cfg=logos_core_real`
+//   so lib.rs picks the working impl.
+// - **`LOGOS_CPP_SDK_DIR` unset** → stub build. No cmake, no bindgen.
+//   lib.rs falls back to a stub `Shim` whose ctor returns an error.
+//   `cargo build --workspace` passes on a Qt-less machine.
+
+use std::env;
+use std::path::PathBuf;
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=LOGOS_CPP_SDK_DIR");
+    println!("cargo:rerun-if-changed=shim/shim.h");
+    println!("cargo:rerun-if-changed=shim/shim.cpp");
+    println!("cargo:rerun-if-changed=shim/CMakeLists.txt");
+    println!("cargo:rerun-if-changed=wrapper.h");
+
+    let Ok(sdk_dir) = env::var("LOGOS_CPP_SDK_DIR") else {
+        write_stub_bindings();
+        return;
+    };
+
+    // ── Real build ──────────────────────────────────────────────────
+    let dst = cmake::Config::new("shim")
+        .define("LOGOS_CPP_SDK_DIR", &sdk_dir)
+        .define("CMAKE_BUILD_TYPE", "Release")
+        .build();
+
+    println!("cargo:rustc-link-search=native={}/lib", dst.display());
+    println!("cargo:rustc-link-lib=static=logos_shim");
+    println!("cargo:rustc-link-lib=static=logos_sdk");
+
+    for lib in &["Qt6Core", "Qt6Network", "Qt6RemoteObjects"] {
+        println!("cargo:rustc-link-lib={lib}");
+    }
+    println!("cargo:rustc-link-lib=boost_system");
+    println!("cargo:rustc-link-lib=ssl");
+    println!("cargo:rustc-link-lib=crypto");
+    println!("cargo:rustc-link-lib=stdc++");
+
+    let bindings = bindgen::Builder::default()
+        .header("wrapper.h")
+        .clang_arg(format!("-I{}/include", dst.display()))
+        .clang_arg("-Ishim")
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
+        .allowlist_function("logos_shim_.*")
+        .allowlist_type("LogosShim")
+        .generate()
+        .expect("bindgen failed");
+
+    let out = PathBuf::from(env::var("OUT_DIR").unwrap()).join("bindings.rs");
+    bindings.write_to_file(&out).expect("write bindings.rs");
+
+    println!("cargo:rustc-cfg=logos_core_real");
+    // Tell rustc about the custom cfg so we don't get an unexpected-cfg
+    // warning on consumer crates.
+    println!("cargo:rustc-check-cfg=cfg(logos_core_real)");
+}
+
+fn write_stub_bindings() {
+    let out = PathBuf::from(env::var("OUT_DIR").unwrap()).join("bindings.rs");
+    std::fs::write(
+        &out,
+        "// stub: LOGOS_CPP_SDK_DIR not set at build time. \
+         Set it to a logos-cpp-sdk checkout to enable real bindings.\n",
+    )
+    .expect("write stub bindings.rs");
+    println!("cargo:rustc-check-cfg=cfg(logos_core_real)");
+}

--- a/crates/logos-core-bindings/shim/CMakeLists.txt
+++ b/crates/logos-core-bindings/shim/CMakeLists.txt
@@ -1,0 +1,44 @@
+cmake_minimum_required(VERSION 3.16)
+project(logos_shim CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+find_package(Qt6 REQUIRED COMPONENTS Core RemoteObjects)
+
+set(LOGOS_CPP_SDK_DIR "" CACHE PATH "Path to logos-cpp-sdk checkout")
+if(NOT LOGOS_CPP_SDK_DIR)
+    message(FATAL_ERROR "Set -DLOGOS_CPP_SDK_DIR=<path-to-logos-cpp-sdk-checkout>.")
+endif()
+
+# Consume the SDK's `logos_sdk` STATIC target — same approach as
+# probe-cpp/. See ../../README.md for the rationale (cherry-picking
+# .cpp files drifts on every SDK update; the SDK already wires Qt +
+# Boost + OpenSSL + nlohmann_json correctly).
+add_subdirectory(${LOGOS_CPP_SDK_DIR}/cpp ${CMAKE_BINARY_DIR}/_logos_sdk)
+
+add_library(logos_shim STATIC shim.cpp)
+
+target_include_directories(logos_shim PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+target_include_directories(logos_shim PRIVATE
+    ${LOGOS_CPP_SDK_DIR}/cpp
+    ${LOGOS_CPP_SDK_DIR}/cpp/implementations/qt_remote
+    ${LOGOS_CPP_SDK_DIR}/core
+)
+
+target_link_libraries(logos_shim PUBLIC
+    logos_sdk
+    Qt6::Core
+    Qt6::RemoteObjects
+)
+
+# Install both archives where cmake-rs expects them. The SDK target
+# normally outputs to `<binary_dir>/lib/liblogos_sdk.a`, but we want
+# both side-by-side under the cmake-rs install prefix so build.rs can
+# point rustc at a single -L.
+install(TARGETS logos_shim ARCHIVE DESTINATION lib)
+install(TARGETS logos_sdk ARCHIVE DESTINATION lib)

--- a/crates/logos-core-bindings/shim/shim.cpp
+++ b/crates/logos-core-bindings/shim/shim.cpp
@@ -1,0 +1,264 @@
+// shim.cpp — see shim.h for the contract + Phase A's findings on why
+// this exists.
+
+#include "shim.h"
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+
+#include <QCoreApplication>
+#include <QDebug>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QLoggingCategory>
+#include <QMetaObject>
+#include <QString>
+#include <QVariant>
+#include <QVariantList>
+
+#include "logos_api.h"
+#include "logos_api_client.h"
+#include "logos_mode.h"
+
+namespace {
+
+// Drop Qt's debug / info logging at the message-handler level so TUI
+// callers don't get their alternate-screen rendering trashed by
+// QtRO's chatty per-call traces. Warnings + critical messages still
+// pass through. Operators who want the verbose output can set
+// `LOGOS_SHIM_VERBOSE=1` in the env.
+void quietQtMessageHandler(QtMsgType type, const QMessageLogContext& ctx, const QString& msg) {
+    if (type == QtDebugMsg || type == QtInfoMsg) return;
+    QByteArray utf8 = msg.toUtf8();
+    fprintf(stderr, "[%s] %s\n",
+            type == QtWarningMsg  ? "warning" :
+            type == QtCriticalMsg ? "critical" :
+            type == QtFatalMsg    ? "fatal" : "?",
+            utf8.constData());
+    if (type == QtFatalMsg) std::abort();
+    (void)ctx;
+}
+
+}  // namespace
+
+namespace {
+
+// argc / argv kept alive for the life of QCoreApplication, which holds
+// references to them. Static so they outlive the lambda that builds the
+// app.
+int g_qt_argc = 1;
+char g_qt_arg0[] = "logos_shim";
+char* g_qt_argv[] = { g_qt_arg0, nullptr };
+
+// Build a heap-allocated null-terminated copy of a QString's UTF-8.
+// Caller frees with free().
+char* dup_qstring(const QString& s) {
+    QByteArray utf8 = s.toUtf8();
+    char* out = static_cast<char*>(std::malloc(utf8.size() + 1));
+    if (!out) return nullptr;
+    std::memcpy(out, utf8.constData(), utf8.size());
+    out[utf8.size()] = '\0';
+    return out;
+}
+
+char* dup_cstr(const char* s) {
+    const size_t n = std::strlen(s);
+    char* out = static_cast<char*>(std::malloc(n + 1));
+    if (!out) return nullptr;
+    std::memcpy(out, s, n + 1);
+    return out;
+}
+
+// Convert a QVariant returned from invokeRemoteMethod into a JSON
+// string the caller can parse uniformly. The Logos SDK / universal
+// module generator typically returns `std::string` of JSON, which the
+// QtRO bridge wraps as QString — so the common case is "raw is a
+// QString that's already JSON". Some modules return QVariantMap or
+// QVariantList; convert those via QJsonDocument::fromVariant.
+QString variant_to_json(const QVariant& raw) {
+    if (!raw.isValid())
+        return QStringLiteral("{\"error\":\"invalid response (no method dispatched?)\"}");
+
+    if (raw.canConvert<QString>()) {
+        QString s = raw.toString();
+        // Heuristic: if the string is already a JSON object/array, return
+        // it as-is. Otherwise wrap it as a JSON string literal so
+        // downstream parsers don't choke.
+        const QString trimmed = s.trimmed();
+        if (trimmed.startsWith('{') || trimmed.startsWith('[') ||
+            trimmed.startsWith('"') || trimmed == QStringLiteral("null") ||
+            trimmed == QStringLiteral("true") || trimmed == QStringLiteral("false")) {
+            return s;
+        }
+        return QJsonDocument(QJsonValue(s).toObject()).toJson(QJsonDocument::Compact);
+    }
+    QJsonDocument d = QJsonDocument::fromVariant(raw);
+    if (d.isObject() || d.isArray())
+        return QString::fromUtf8(d.toJson(QJsonDocument::Compact));
+
+    // Last resort: stringify whatever it is.
+    return QStringLiteral("{\"error\":\"unsupported response type: %1\"}")
+        .arg(QString::fromUtf8(raw.typeName()));
+}
+
+}  // namespace
+
+struct LogosShim {
+    std::thread qt_thread;
+    QCoreApplication* app = nullptr;
+    LogosAPI* api = nullptr;
+
+    // Set true once `app` and `api` are both constructed and the Qt
+    // event loop is about to enter exec(). Callers wait on this before
+    // their first call.
+    std::atomic<bool> ready{false};
+    std::mutex ready_mu;
+    std::condition_variable ready_cv;
+};
+
+LogosShim* logos_shim_new(const char* module_name) {
+    if (!module_name) return nullptr;
+    auto* shim = new LogosShim();
+    const std::string mn = module_name;
+
+    shim->qt_thread = std::thread([shim, mn]() {
+        // Install the quiet message handler before any Qt class logs.
+        // Operators who want verbose tracing (debugging the bridge,
+        // not running the TUI) can opt in via env.
+        if (!std::getenv("LOGOS_SHIM_VERBOSE")) {
+            qInstallMessageHandler(quietQtMessageHandler);
+        }
+
+        QCoreApplication app(g_qt_argc, g_qt_argv);
+        app.setApplicationName(QStringLiteral("logos_shim"));
+
+        LogosModeConfig::setMode(LogosMode::Remote);
+        LogosAPI api(QString::fromStdString(mn));
+
+        shim->app = &app;
+        shim->api = &api;
+        {
+            std::lock_guard<std::mutex> lk(shim->ready_mu);
+            shim->ready.store(true, std::memory_order_release);
+            shim->ready_cv.notify_all();
+        }
+        app.exec();
+        // app and api destruct here as the function unwinds.
+        shim->app = nullptr;
+        shim->api = nullptr;
+    });
+
+    // Wait for the Qt thread to publish its app + api pointers.
+    std::unique_lock<std::mutex> lk(shim->ready_mu);
+    shim->ready_cv.wait(lk, [&]() { return shim->ready.load(std::memory_order_acquire); });
+    return shim;
+}
+
+char* logos_shim_call(LogosShim* shim,
+                      const char* target_module,
+                      const char* method,
+                      const char* args_json,
+                      int timeout_ms) {
+    if (!shim || !target_module || !method)
+        return dup_cstr("{\"error\":\"shim or required arg is null\"}");
+    if (!shim->api || !shim->app)
+        return dup_cstr("{\"error\":\"shim not ready\"}");
+    if (timeout_ms <= 0) timeout_ms = 30'000;
+
+    // Per-call sync state. Captured by the lambda; the lambda runs on
+    // the Qt thread, this function's stack stays alive because we
+    // block on done_cv until either the lambda finishes or the outer
+    // timeout fires.
+    struct Slot {
+        std::mutex mu;
+        std::condition_variable cv;
+        bool done = false;
+        QString result;
+    };
+    auto slot = std::make_shared<Slot>();
+
+    const std::string target = target_module;
+    const std::string meth = method;
+    const std::string args = args_json ? args_json : "[]";
+
+    QMetaObject::invokeMethod(shim->app, [shim, slot, target, meth, args, timeout_ms]() {
+        QString out;
+        QVariantList vargs;
+        if (!args.empty()) {
+            QJsonParseError err{};
+            QJsonDocument doc = QJsonDocument::fromJson(QByteArray::fromStdString(args), &err);
+            if (err.error != QJsonParseError::NoError) {
+                out = QStringLiteral("{\"error\":\"args_json parse failed: %1\"}").arg(err.errorString());
+            } else if (!doc.isArray()) {
+                out = QStringLiteral("{\"error\":\"args_json must be a JSON array\"}");
+            } else {
+                vargs = doc.array().toVariantList();
+            }
+        }
+
+        if (out.isEmpty()) {
+            auto* client = shim->api->getClient(QString::fromStdString(target));
+            if (!client) {
+                out = QStringLiteral("{\"error\":\"getClient(\\\"%1\\\") returned null\"}").arg(QString::fromStdString(target));
+            } else {
+                QVariant raw = client->invokeRemoteMethod(
+                    QString::fromStdString(target),
+                    QString::fromStdString(meth),
+                    vargs,
+                    Timeout(timeout_ms));
+                out = variant_to_json(raw);
+            }
+        }
+
+        {
+            std::lock_guard<std::mutex> lk(slot->mu);
+            slot->result = std::move(out);
+            slot->done = true;
+            slot->cv.notify_all();
+        }
+    }, Qt::QueuedConnection);
+
+    // Outer timeout: SDK timeout + a 5 s grace window. If we hit it,
+    // QtRO is wedged (registry not reachable) and we want to surface
+    // that rather than hang the caller forever.
+    const auto deadline = std::chrono::steady_clock::now() +
+                          std::chrono::milliseconds(timeout_ms + 5'000);
+    std::unique_lock<std::mutex> lk(slot->mu);
+    if (!slot->cv.wait_until(lk, deadline, [&]() { return slot->done; })) {
+        // Note: the Qt thread may still be holding the lambda alive
+        // when this fires. The shared_ptr<Slot> keeps the slot alive
+        // until the lambda also drops its reference, so a later
+        // notification doesn't dangle.
+        return dup_cstr("{\"error\":\"shim outer timeout exceeded — QtRO registry probably unreachable\"}");
+    }
+
+    char* result = dup_qstring(slot->result);
+    return result ? result : dup_cstr("{\"error\":\"shim oom on result copy\"}");
+}
+
+void logos_shim_free_str(char* s) {
+    if (s) std::free(s);
+}
+
+void logos_shim_destroy(LogosShim* shim) {
+    if (!shim) return;
+    if (shim->app) {
+        // Quit the event loop on its own thread; exec() returns and
+        // the Qt thread function finishes.
+        QMetaObject::invokeMethod(shim->app, []() {
+            QCoreApplication::quit();
+        }, Qt::QueuedConnection);
+    }
+    if (shim->qt_thread.joinable()) {
+        shim->qt_thread.join();
+    }
+    delete shim;
+}

--- a/crates/logos-core-bindings/shim/shim.h
+++ b/crates/logos-core-bindings/shim/shim.h
@@ -1,0 +1,72 @@
+// C ABI shim over LogosAPI. Phase B of the experiment tracked in
+// https://github.com/vpavlin/lmao/issues/19 — see ../../README.md.
+//
+// The shim owns a QCoreApplication on a dedicated thread, owns a
+// `LogosAPI` instance, and serialises calls onto the Qt thread via
+// QMetaObject::invokeMethod(Qt::QueuedConnection). Callers from any
+// thread (Rust's tokio runtime, plain Rust threads, …) get a
+// blocking C-callable interface that deals only in C strings + ints.
+//
+// JSON in, JSON out. The caller passes args as a JSON array string
+// ("[]" for no-arg methods, '["pubkey","text"]' for typed args).
+// Inside, the shim parses it to QVariantList, marshals to the Qt
+// thread, calls invokeRemoteMethod, serialises the QVariant result
+// back to JSON. The caller frees the result with
+// `logos_shim_free_str`.
+//
+// Thread safety: `logos_shim_call` is reentrant — multiple threads
+// may call it concurrently. Each call gets its own
+// (mutex, condvar, done flag, result) tuple captured by the lambda
+// posted to the Qt thread; the Qt thread serialises the actual
+// invokeRemoteMethod calls.
+//
+// Outer timeout: `timeout_ms` IS honored even when the QtRO registry
+// is unreachable (which is what bit Phase A — see README). The shim
+// adds a small grace window on top of the value passed to
+// `Timeout(...)` so the inner SDK timeout fires before the outer one.
+//
+// Lifetime: `logos_shim_destroy` posts a quit to the Qt event loop
+// and joins the thread. After that the handle is invalid; do not
+// reuse.
+
+#ifndef LOGOS_SHIM_H
+#define LOGOS_SHIM_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct LogosShim LogosShim;
+
+// Create the shim: spin up the Qt thread, instantiate LogosAPI(module_name).
+// `module_name` is what other modules see in the registry — pick a name
+// distinct from real modules' names so logoscore-side logs stay readable.
+// Returns NULL on failure (e.g. `module_name` is NULL or the Qt thread
+// fails to start). Caller must `logos_shim_destroy` to clean up.
+LogosShim* logos_shim_new(const char* module_name);
+
+// Synchronously invoke a method on a target module. Blocks for at most
+// `timeout_ms` plus a small grace window. Returns a heap-allocated,
+// null-terminated JSON string the caller MUST free with
+// `logos_shim_free_str`. Always non-NULL on a clean call — on errors,
+// returns a JSON object of one of the shapes the agent module already
+// emits (`{"error": "..."}` or `{"kind": "error", "message": "..."}`)
+// so consumers can use a single parser.
+char* logos_shim_call(LogosShim* shim,
+                      const char* target_module,
+                      const char* method,
+                      const char* args_json,
+                      int timeout_ms);
+
+// Free a string returned by `logos_shim_call`. Idempotent for NULL.
+void logos_shim_free_str(char* s);
+
+// Stop the Qt thread, tear down LogosAPI, free the shim. Idempotent
+// for NULL. The handle is invalid after this returns.
+void logos_shim_destroy(LogosShim* shim);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // LOGOS_SHIM_H

--- a/crates/logos-core-bindings/src/lib.rs
+++ b/crates/logos-core-bindings/src/lib.rs
@@ -1,0 +1,171 @@
+// Rust bindings to the Logos C++ SDK's LogosAPI, via a C-callable
+// shim that lives in `shim/`. JSON in / JSON out; the Rust crate
+// never sees a Qt type.
+//
+// Two build modes, picked by build.rs based on the `LOGOS_CPP_SDK_DIR`
+// env var:
+//
+// - **Real bindings** (env set) — cmake builds the shim + the SDK's
+//   `logos_sdk` static archive; bindgen wraps `shim.h`; rustc links
+//   both. `Shim::new` boots a Qt event-loop thread + a `LogosAPI`
+//   instance; `Shim::call` dispatches synchronously over QtRO.
+// - **Stub bindings** (env unset) — `Shim::new` returns
+//   `Error::NotCompiledIn` with a hint about how to enable the real
+//   build. Lets `cargo check --workspace` pass on a host without
+//   Qt6 / Boost / OpenSSL / the SDK installed, which is what CI sees.
+//
+// build.rs emits `cargo:rustc-cfg=logos_core_real` in the real-build
+// case; the two `Shim` impls below sit behind a matching cfg.
+
+#![allow(non_camel_case_types, non_snake_case, dead_code)]
+
+use std::fmt;
+
+#[derive(Debug)]
+pub enum Error {
+    /// The crate was built without `LOGOS_CPP_SDK_DIR` set — the real
+    /// FFI layer was stubbed out. Rebuild with the env var pointing at
+    /// a logos-cpp-sdk checkout to enable Shim.
+    NotCompiledIn,
+    /// The shim's `logos_shim_new` returned NULL (allocation failure
+    /// or Qt thread couldn't start).
+    InitFailed,
+    /// Caller passed a string containing an interior NUL byte.
+    NulInArg(&'static str),
+    /// Shim returned a byte sequence that isn't UTF-8.
+    InvalidUtf8,
+    /// The shim returned a JSON error response. The string is the raw
+    /// JSON. Shapes mirror the agent module's:
+    ///   `{"error": "..."}`
+    ///   `{"kind": "error", "message": "..."}`
+    ShimError(String),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::NotCompiledIn => write!(
+                f,
+                "logos-core-bindings was built without LOGOS_CPP_SDK_DIR — \
+                 set the env var to a logos-cpp-sdk checkout and rebuild."
+            ),
+            Error::InitFailed => write!(f, "logos_shim_new returned null"),
+            Error::NulInArg(name) => write!(f, "interior NUL in arg: {name}"),
+            Error::InvalidUtf8 => write!(f, "shim returned non-UTF-8 string"),
+            Error::ShimError(s) => write!(f, "shim error: {s}"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+// ── Real impl — only when build.rs found LOGOS_CPP_SDK_DIR ─────────
+
+#[cfg(logos_core_real)]
+mod real {
+    use super::Error;
+    use std::ffi::{CStr, CString};
+    use std::os::raw::c_char;
+
+    mod ffi {
+        include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+    }
+
+    pub struct Shim {
+        inner: *mut ffi::LogosShim,
+    }
+
+    // Safe: the C++ shim is internally synchronised; calls from any
+    // Rust thread are dispatched onto the Qt thread via QueuedConnection.
+    unsafe impl Send for Shim {}
+    unsafe impl Sync for Shim {}
+
+    impl Shim {
+        pub fn new(module_name: &str) -> Result<Self, Error> {
+            let cname = CString::new(module_name).map_err(|_| Error::NulInArg("module_name"))?;
+            // SAFETY: cname lives for the call.
+            let inner = unsafe { ffi::logos_shim_new(cname.as_ptr()) };
+            if inner.is_null() {
+                return Err(Error::InitFailed);
+            }
+            Ok(Self { inner })
+        }
+
+        pub fn call(
+            &self,
+            target_module: &str,
+            method: &str,
+            args_json: &str,
+            timeout_ms: i32,
+        ) -> Result<String, Error> {
+            let target = CString::new(target_module).map_err(|_| Error::NulInArg("target"))?;
+            let meth = CString::new(method).map_err(|_| Error::NulInArg("method"))?;
+            let args = CString::new(args_json).map_err(|_| Error::NulInArg("args_json"))?;
+
+            // SAFETY: CStrings live for the call; returned pointer is
+            // shim-heap-allocated, freed below.
+            let raw = unsafe {
+                ffi::logos_shim_call(
+                    self.inner,
+                    target.as_ptr(),
+                    meth.as_ptr(),
+                    args.as_ptr(),
+                    timeout_ms,
+                )
+            };
+            if raw.is_null() {
+                return Err(Error::ShimError(
+                    "{\"error\":\"shim returned null pointer\"}".into(),
+                ));
+            }
+            let s = unsafe { CStr::from_ptr(raw) }
+                .to_str()
+                .map(str::to_owned)
+                .map_err(|_| Error::InvalidUtf8);
+            unsafe { ffi::logos_shim_free_str(raw as *mut c_char) };
+            s
+        }
+    }
+
+    impl Drop for Shim {
+        fn drop(&mut self) {
+            if !self.inner.is_null() {
+                // SAFETY: we own the pointer; only dropped once.
+                unsafe { ffi::logos_shim_destroy(self.inner) };
+                self.inner = std::ptr::null_mut();
+            }
+        }
+    }
+}
+
+// ── Stub impl — when LOGOS_CPP_SDK_DIR wasn't set at build time ─────
+
+#[cfg(not(logos_core_real))]
+mod real {
+    use super::Error;
+
+    pub struct Shim;
+
+    impl Shim {
+        pub fn new(_module_name: &str) -> Result<Self, Error> {
+            Err(Error::NotCompiledIn)
+        }
+        pub fn call(
+            &self,
+            _target_module: &str,
+            _method: &str,
+            _args_json: &str,
+            _timeout_ms: i32,
+        ) -> Result<String, Error> {
+            Err(Error::NotCompiledIn)
+        }
+    }
+}
+
+pub use real::Shim;
+
+/// Whether this build of the crate has the real FFI compiled in.
+/// `false` when `LOGOS_CPP_SDK_DIR` wasn't set at build time.
+pub fn is_real_build() -> bool {
+    cfg!(logos_core_real)
+}

--- a/crates/logos-core-bindings/wrapper.h
+++ b/crates/logos-core-bindings/wrapper.h
@@ -1,0 +1,4 @@
+// Bindgen entry point — only the shim's narrow C ABI is in scope.
+// Qt / SDK headers are explicitly excluded from this surface; the
+// shim is exactly the boundary that hides them from Rust.
+#include "shim.h"


### PR DESCRIPTION
First foundation PR for #19. Lifts the experimental shim from `experiments/rust-logos-api/rust-shim/` into the workspace as `crates/logos-core-bindings`.

Two build modes picked by `build.rs` based on `LOGOS_CPP_SDK_DIR`:

- **Real** — cmake builds the shim + SDK static archive; bindgen wraps the C ABI; `Shim` works. Cfg `logos_core_real` is set.
- **Stub** — no cmake, no bindgen. `Shim::new` returns `Error::NotCompiledIn`. CI without Qt6 + the SDK installed still gets a green `cargo check --workspace`.

The two impls sit behind matching cfgs in `src/lib.rs`; public `Shim` re-exports whichever is active. Verified `cargo fmt --check`, `cargo clippy --workspace`, `cargo check --workspace`, and the real build path against a local SDK checkout.

Foundation for the storage / messaging / CLI runtime migrations stacked on top. The `experiments/rust-logos-api/` scaffold stays put as the reference / development sandbox until everything graduates.

Refs: #19