### PR TITLE
refactor(logos-core-bindings): event subscription — listen + poll_event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,8 @@ dist/
 # Drop this entry if you want to publish slides alongside the code.
 /slides/
 /SLIDES_CONTEXT.md
+
+# Nix build-output symlinks in experiments/ that point at /nix/store
+# paths meaningless on anyone else's machine.
+/experiments/**/result
+/experiments/**/result-*

--- a/crates/logos-core-bindings/shim/shim.cpp
+++ b/crates/logos-core-bindings/shim/shim.cpp
@@ -8,10 +8,12 @@
 #include <condition_variable>
 #include <cstdlib>
 #include <cstring>
+#include <deque>
 #include <memory>
 #include <mutex>
 #include <string>
 #include <thread>
+#include <vector>
 
 #include <QCoreApplication>
 #include <QDebug>
@@ -27,6 +29,7 @@
 #include "logos_api.h"
 #include "logos_api_client.h"
 #include "logos_mode.h"
+#include "logos_object.h"
 
 namespace {
 
@@ -122,6 +125,21 @@ struct LogosShim {
     std::atomic<bool> ready{false};
     std::mutex ready_mu;
     std::condition_variable ready_cv;
+
+    // ── Event subscription state ─────────────────────────────────
+    //
+    // Cross-thread queue between the Qt thread (eventResponse slots
+    // enqueue here) and the Rust caller's polling thread
+    // (logos_shim_poll_event dequeues). The queue stores ready-to-
+    // hand-out JSON strings already in the
+    //   {"module": …, "event": …, "data": …}
+    // shape so dequeue is just a string copy.
+    std::mutex events_mu;
+    std::condition_variable events_cv;
+    std::deque<std::string> events;
+    // Modules we've already connected an eventResponse slot for.
+    // Calling logos_shim_listen twice for the same module is a no-op.
+    std::vector<std::string> listened;
 };
 
 LogosShim* logos_shim_new(const char* module_name) {
@@ -242,6 +260,78 @@ char* logos_shim_call(LogosShim* shim,
 
     char* result = dup_qstring(slot->result);
     return result ? result : dup_cstr("{\"error\":\"shim oom on result copy\"}");
+}
+
+int logos_shim_listen(LogosShim* shim, const char* module_name, const char* event_name) {
+    if (!shim || !shim->app || !shim->api || !module_name || !event_name) return 0;
+
+    const std::string mn = module_name;
+    const std::string en = event_name;
+    std::atomic<bool> ok{false};
+
+    // Run the actual connect() on the Qt thread (Qt object affinity).
+    // BlockingQueuedConnection so we don't return before the slot is wired.
+    QMetaObject::invokeMethod(
+        shim->app,
+        [shim, mn, en, &ok]() {
+            const std::string key = mn + "\0" + en;
+            // De-dupe: skip if we've already registered this (module, event).
+            for (const auto& k : shim->listened) {
+                if (k == key) {
+                    ok.store(true);
+                    return;
+                }
+            }
+            auto* client = shim->api->getClient(QString::fromStdString(mn));
+            if (!client) return;
+            auto* obj = client->requestObject(QString::fromStdString(mn), Timeout(5000));
+            if (!obj) return;
+            client->onEvent(
+                obj,
+                QString::fromStdString(en),
+                [shim, mn, en](const QString& eventName, const QVariantList& data) {
+                    // Serialise (module, event, data) into a JSON string and
+                    // enqueue. `data` is a QVariantList — already a JSON-array
+                    // shape; convert and embed.
+                    QJsonArray jsonData = QJsonArray::fromVariantList(data);
+                    QJsonObject event;
+                    event["module"] = QString::fromStdString(mn);
+                    event["event"] = eventName;
+                    event["data"] = jsonData;
+                    const std::string s =
+                        QJsonDocument(event).toJson(QJsonDocument::Compact).toStdString();
+                    {
+                        std::lock_guard<std::mutex> lk(shim->events_mu);
+                        shim->events.push_back(s);
+                    }
+                    shim->events_cv.notify_one();
+                    (void)en;
+                });
+            shim->listened.push_back(key);
+            ok.store(true);
+        },
+        Qt::BlockingQueuedConnection);
+
+    return ok.load() ? 1 : 0;
+}
+
+char* logos_shim_poll_event(LogosShim* shim, int timeout_ms) {
+    if (!shim) return nullptr;
+    if (timeout_ms < 0) timeout_ms = 0;
+
+    std::unique_lock<std::mutex> lk(shim->events_mu);
+    if (shim->events.empty()) {
+        // Wait up to timeout_ms for an event.
+        shim->events_cv.wait_for(
+            lk,
+            std::chrono::milliseconds(timeout_ms),
+            [shim]() { return !shim->events.empty(); });
+    }
+    if (shim->events.empty()) return nullptr;
+    std::string ev = std::move(shim->events.front());
+    shim->events.pop_front();
+    lk.unlock();
+    return dup_cstr(ev.c_str());
 }
 
 void logos_shim_free_str(char* s) {

--- a/crates/logos-core-bindings/shim/shim.h
+++ b/crates/logos-core-bindings/shim/shim.h
@@ -58,7 +58,31 @@ char* logos_shim_call(LogosShim* shim,
                       const char* args_json,
                       int timeout_ms);
 
-// Free a string returned by `logos_shim_call`. Idempotent for NULL.
+// Register a callback for a specific (module, event_name) pair. After
+// this returns, any `emitEvent(event_name, data)` the module emits gets
+// captured and enqueued; `logos_shim_poll_event` drains the queue.
+// Returns 1 on success, 0 if the client / object couldn't be obtained
+// (registry unreachable, module not loaded, etc.).
+// Calling repeatedly with the same (module, event) pair is harmless;
+// the shim de-duplicates internally.
+int logos_shim_listen(LogosShim* shim, const char* module_name, const char* event_name);
+
+// Block up to `timeout_ms` for the next queued event from any module
+// we're listening to. Returns NULL on timeout. Otherwise returns a
+// heap-allocated JSON object the caller MUST free with
+// `logos_shim_free_str`:
+//   {"module": "<from logos_shim_listen>", "event": "<name>", "data": <payload>}
+// `data` is whatever the module emitted in its eventResponse —
+// already deserialised from the QVariantList into a JSON array (one
+// entry per QVariant), so the typical agent-module pattern of
+// `emitEvent(name, json_string)` arrives as `data = ["<json>"]`.
+//
+// Use a small timeout (e.g. 100 ms) in a tight poll loop, or a
+// larger one when you're idle.
+char* logos_shim_poll_event(LogosShim* shim, int timeout_ms);
+
+// Free a string returned by `logos_shim_call` or `logos_shim_poll_event`.
+// Idempotent for NULL.
 void logos_shim_free_str(char* s);
 
 // Stop the Qt thread, tear down LogosAPI, free the shim. Idempotent

--- a/crates/logos-core-bindings/src/lib.rs
+++ b/crates/logos-core-bindings/src/lib.rs
@@ -125,6 +125,41 @@ mod real {
             unsafe { ffi::logos_shim_free_str(raw as *mut c_char) };
             s
         }
+
+        /// Register interest in `event_name` from `module`. After this
+        /// returns, matching events get enqueued; drain with `poll_event`.
+        /// Repeated calls with the same pair are de-duped by the shim.
+        pub fn listen(&self, module: &str, event_name: &str) -> Result<(), Error> {
+            let m = CString::new(module).map_err(|_| Error::NulInArg("module"))?;
+            let e = CString::new(event_name).map_err(|_| Error::NulInArg("event_name"))?;
+            // SAFETY: both CStrings live for the call.
+            let ok = unsafe { ffi::logos_shim_listen(self.inner, m.as_ptr(), e.as_ptr()) };
+            if ok == 1 {
+                Ok(())
+            } else {
+                Err(Error::ShimError(format!(
+                    "{{\"error\":\"listen({module}, {event_name}) failed — module not loaded?\"}}"
+                )))
+            }
+        }
+
+        /// Block up to `timeout_ms` for the next queued event from any
+        /// previously-listened (module, event) pair. `Ok(None)` on
+        /// timeout, `Ok(Some(json))` on event. JSON shape:
+        /// `{"module": "...", "event": "...", "data": [...]}`.
+        pub fn poll_event(&self, timeout_ms: i32) -> Result<Option<String>, Error> {
+            // SAFETY: returned pointer is shim-heap-allocated or NULL.
+            let raw = unsafe { ffi::logos_shim_poll_event(self.inner, timeout_ms) };
+            if raw.is_null() {
+                return Ok(None);
+            }
+            let s = unsafe { CStr::from_ptr(raw) }
+                .to_str()
+                .map(str::to_owned)
+                .map_err(|_| Error::InvalidUtf8);
+            unsafe { ffi::logos_shim_free_str(raw as *mut c_char) };
+            s.map(Some)
+        }
     }
 
     impl Drop for Shim {
@@ -157,6 +192,12 @@ mod real {
             _args_json: &str,
             _timeout_ms: i32,
         ) -> Result<String, Error> {
+            Err(Error::NotCompiledIn)
+        }
+        pub fn listen(&self, _module: &str, _event_name: &str) -> Result<(), Error> {
+            Err(Error::NotCompiledIn)
+        }
+        pub fn poll_event(&self, _timeout_ms: i32) -> Result<Option<String>, Error> {
             Err(Error::NotCompiledIn)
         }
     }


### PR DESCRIPTION
Stacked on #21. Adds the pull-based event channel that both the storage and messaging migrations need.

Sync-only LogosAPI calls aren't enough on their own:
- `storage_module.uploadUrl` emits CID via `storageUploadDone` event.
- `delivery_module.subscribe` delivers messages via `messageReceived` event.

Both need to capture `eventResponse` signals from the SDK side. This PR wires that.

## New C ABI

```c
int  logos_shim_listen(LogosShim*, const char* module, const char* event);
char* logos_shim_poll_event(LogosShim*, int timeout_ms);
```

## Implementation

- `LogosShim` grows a `std::deque<std::string>` + mutex/condvar as a cross-thread queue.
- `listen()` runs on the Qt thread (BlockingQueuedConnection) so `client->requestObject(...)` + `client->onEvent(...)` happen with proper QObject affinity. Callback pushes `{"module":..., "event":..., "data":[...]}` onto the queue + notifies condvar.
- `poll_event()` is callable from any thread; waits up to `timeout_ms` for an event, returns a heap copy of the front-of-queue JSON string.
- De-duplication: a vector of `module\0event` keys tracks already-wired pairs so repeated `listen()` calls are no-ops.

## Rust side

`Shim::listen(module, event)` and `Shim::poll_event(timeout_ms) -> Result<Option<String>>` on the real impl; both `Err(NotCompiledIn)` on the stub.

## Test plan

- [x] `cargo check -p logos-core-bindings` — stub mode.
- [x] `cargo check -p logos-core-bindings` with `LOGOS_CPP_SDK_DIR` set — real mode compiles, links the new shim symbols.
- [x] `cargo fmt --check` + `cargo clippy --all-targets` — clean.
- [ ] End-to-end (subscribe to `agent.delegate_complete` and catch it in `poll_event`) — happens in the storage / messaging migration PRs that consume this.

## Stacked on

#21. Merge that first.

Refs: #19