### PR TITLE
refactor(cli): --transport delivery-module + --storage storage-module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2165,6 +2165,7 @@ dependencies = [
  "hex",
  "k256",
  "libc",
+ "logos-core-bindings",
  "logos-messaging-a2a-core",
  "logos-messaging-a2a-crypto",
  "logos-messaging-a2a-node",

--- a/crates/logos-messaging-a2a-cli/Cargo.toml
+++ b/crates/logos-messaging-a2a-cli/Cargo.toml
@@ -12,6 +12,15 @@ default = ["rest"]
 rest = ["logos-messaging-a2a-transport/rest"]
 logos-delivery = ["logos-messaging-a2a-transport/logos-delivery"]
 libstorage = ["logos-messaging-a2a-storage/libstorage"]
+# Pulls in the LogosAPI shim backends: the CLI builds one shared
+# `Arc<Shim>` and hands it to both the storage and transport builders.
+# Picks up `LOGOS_INSTANCE_ID` from the env, so launching the CLI as a
+# child of `logoscore` / Basecamp Just Works.
+shim = [
+    "dep:logos-core-bindings",
+    "logos-messaging-a2a-transport/delivery-module",
+    "logos-messaging-a2a-storage/storage-module",
+]
 
 [dependencies]
 logos-messaging-a2a-crypto = { path = "../logos-messaging-a2a-crypto" }
@@ -19,6 +28,7 @@ logos-messaging-a2a-core = { path = "../logos-messaging-a2a-core" }
 logos-messaging-a2a-transport = { path = "../logos-messaging-a2a-transport", default-features = false }
 logos-messaging-a2a-storage = { path = "../logos-messaging-a2a-storage", default-features = false }
 logos-messaging-a2a-node = { path = "../logos-messaging-a2a-node" }
+logos-core-bindings = { path = "../logos-core-bindings", optional = true }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/logos-messaging-a2a-cli/src/cli.rs
+++ b/crates/logos-messaging-a2a-cli/src/cli.rs
@@ -12,6 +12,11 @@ pub enum TransportKind {
     /// External nwaku node over the REST API.
     #[cfg(feature = "rest")]
     Rest,
+    /// Basecamp's `delivery_module`, reached via the LogosAPI shim.
+    /// Use this when the agent runs inside (or as a child of) a
+    /// `logoscore` / Basecamp host with `delivery_module` loaded.
+    #[cfg(feature = "shim")]
+    DeliveryModule,
 }
 
 /// Optional storage backend for offloading exec audit logs (and, in
@@ -26,6 +31,11 @@ pub enum StorageKind {
     /// Embedded Logos Storage (Codex) node via libstorage FFI.
     #[cfg(feature = "libstorage")]
     Libstorage,
+    /// Basecamp's `storage_module`, reached via the LogosAPI shim.
+    /// Use this when the agent runs inside (or as a child of) a
+    /// `logoscore` / Basecamp host with `storage_module` loaded.
+    #[cfg(feature = "shim")]
+    StorageModule,
 }
 
 #[cfg(not(any(feature = "logos-delivery", feature = "rest")))]
@@ -109,6 +119,15 @@ pub struct Cli {
     /// running peer's `lmao storage info` output (or its startup log).
     #[arg(long = "storage-bootstrap", global = true)]
     pub storage_bootstrap: Vec<String>,
+
+    /// JSON config passed to `delivery_module.createNode(cfg)` when
+    /// `--transport delivery-module` is selected. If unset, the CLI
+    /// asks `delivery_module.getAvailableConfigs()` and picks the
+    /// preset matching `--preset`. Override when you need a non-default
+    /// pubsub mesh, port pinning, or a custom cluster id.
+    #[cfg(feature = "shim")]
+    #[arg(long, global = true)]
+    pub delivery_module_cfg: Option<String>,
 
     /// Path to the trust list TOML file. `agent run` loads it on
     /// startup; the `lmao trust` subcommands read/write it. Defaults to

--- a/crates/logos-messaging-a2a-cli/src/info.rs
+++ b/crates/logos-messaging-a2a-cli/src/info.rs
@@ -97,7 +97,15 @@ async fn print_via_daemon(client: &DaemonClient, json: bool) -> Result<()> {
 }
 
 async fn print_via_ephemeral(cli: &Cli) -> Result<()> {
-    let transport = crate::build_transport(cli).await?;
+    // info's ephemeral fallback never needs a shim — if the user
+    // selected --transport delivery-module they should already be
+    // running through a daemon. Pass `None` to keep this path simple.
+    let transport = crate::build_transport(
+        cli,
+        #[cfg(feature = "shim")]
+        None,
+    )
+    .await?;
     let identity = IdentityConfig {
         keyfile: cli.keyfile.clone(),
         encrypt: cli.encrypt,

--- a/crates/logos-messaging-a2a-cli/src/main.rs
+++ b/crates/logos-messaging-a2a-cli/src/main.rs
@@ -9,6 +9,8 @@ mod info;
 mod metrics;
 mod presence;
 mod session;
+#[cfg(feature = "shim")]
+mod shim;
 mod storage;
 mod task;
 mod trust;
@@ -92,18 +94,38 @@ async fn main() -> Result<()> {
         .probe()
         .await;
 
+    // Optional shim — only built when a shim-backed transport or
+    // storage variant is selected. Constructed once and shared so both
+    // backends drive the same LogosAPI consumer / Qt event loop.
+    #[cfg(feature = "shim")]
+    let shim_handle = if !daemon_can_handle && shim::cli_needs_shim(&cli) {
+        Some(shim::build(&cli)?)
+    } else {
+        None
+    };
+
     let transport: Arc<dyn Transport> = if daemon_can_handle {
         // Placeholder. None of the daemon-aware code paths actually
         // touch this transport — the handlers route through IPC and
         // return before falling back to it.
         Arc::new(logos_messaging_a2a_transport::memory::InMemoryTransport::new())
     } else {
-        build_transport(&cli).await?
+        build_transport(
+            &cli,
+            #[cfg(feature = "shim")]
+            shim_handle.clone(),
+        )
+        .await?
     };
     let storage: Option<Arc<dyn StorageBackend>> = if daemon_can_handle {
         None
     } else {
-        build_storage(&cli).await?
+        build_storage(
+            &cli,
+            #[cfg(feature = "shim")]
+            shim_handle.clone(),
+        )
+        .await?
     };
 
     match cli.command {
@@ -144,7 +166,10 @@ async fn main() -> Result<()> {
 /// command handlers can share a single signature. Also used by daemon-
 /// aware handlers (e.g. `info`) on the fallback path when no daemon is
 /// listening.
-pub(crate) async fn build_transport(cli: &Cli) -> Result<Arc<dyn Transport>> {
+pub(crate) async fn build_transport(
+    cli: &Cli,
+    #[cfg(feature = "shim")] shim: Option<Arc<logos_core_bindings::Shim>>,
+) -> Result<Arc<dyn Transport>> {
     match cli.transport {
         #[cfg(feature = "logos-delivery")]
         TransportKind::LogosDelivery => {
@@ -175,14 +200,71 @@ pub(crate) async fn build_transport(cli: &Cli) -> Result<Arc<dyn Transport>> {
             use logos_messaging_a2a_transport::nwaku_rest::LogosMessagingTransport;
             Ok(Arc::new(LogosMessagingTransport::new(&cli.waku)))
         }
+        #[cfg(feature = "shim")]
+        TransportKind::DeliveryModule => {
+            use logos_messaging_a2a_transport::DeliveryModuleTransport;
+            let shim = shim.ok_or_else(|| {
+                anyhow::anyhow!("--transport delivery-module requires the shim to be available")
+            })?;
+            // No explicit cfg? Fall back to delivery_module's preset
+            // catalog. Tries `--preset` first, then the first preset
+            // the module reports; if none, errors with the catalog so
+            // the user can pick.
+            let cfg_json = match cli.delivery_module_cfg.clone() {
+                Some(c) => c,
+                None => shim_delivery_cfg_from_preset(&shim, &cli.preset).await?,
+            };
+            let t = DeliveryModuleTransport::new(shim, &cfg_json)
+                .await
+                .map_err(|e| anyhow::anyhow!("delivery_module transport: {e}"))?;
+            Ok(Arc::new(t))
+        }
     }
+}
+
+/// Ask `delivery_module.getAvailableConfigs()` for its preset catalog
+/// and return the JSON config for `preset`. Used when the user picks
+/// `--transport delivery-module` without an explicit `--delivery-module-cfg`.
+#[cfg(feature = "shim")]
+async fn shim_delivery_cfg_from_preset(
+    shim: &logos_core_bindings::Shim,
+    preset: &str,
+) -> Result<String> {
+    // getAvailableConfigs returns a JSON-encoded map { preset: cfgJson, ... }
+    let raw = shim
+        .call("delivery_module", "getAvailableConfigs", "[]", 10_000)
+        .map_err(|e| anyhow::anyhow!("delivery_module getAvailableConfigs: {e}"))?;
+    let map: serde_json::Value = serde_json::from_str(&raw)
+        .map_err(|e| anyhow::anyhow!("getAvailableConfigs returned non-JSON: {e}"))?;
+    // The catalog may arrive as either a {"value": {...}} envelope or
+    // a bare map — accept both.
+    let catalog = map.get("value").unwrap_or(&map);
+    if let Some(cfg) = catalog.get(preset) {
+        // Each entry is itself JSON-encoded (delivery_module historically
+        // returned strings). Tolerate both shapes.
+        return Ok(match cfg {
+            serde_json::Value::String(s) => s.clone(),
+            other => other.to_string(),
+        });
+    }
+    let presets: Vec<String> = catalog
+        .as_object()
+        .map(|m| m.keys().cloned().collect())
+        .unwrap_or_default();
+    anyhow::bail!(
+        "preset `{preset}` not in delivery_module catalog (available: {presets:?}). \
+         Override with --delivery-module-cfg <json>."
+    )
 }
 
 /// Construct the chosen storage backend, if any. Returns `Ok(None)` when
 /// the user picked `--storage none` so callers don't need to thread a
 /// dummy backend through the call sites.
 #[allow(dead_code)] // also re-exported to daemon-aware fallback paths
-pub(crate) async fn build_storage(cli: &Cli) -> Result<Option<Arc<dyn StorageBackend>>> {
+pub(crate) async fn build_storage(
+    cli: &Cli,
+    #[cfg(feature = "shim")] shim: Option<Arc<logos_core_bindings::Shim>>,
+) -> Result<Option<Arc<dyn StorageBackend>>> {
     match cli.storage {
         StorageKind::None => Ok(None),
         #[cfg(feature = "libstorage")]
@@ -209,6 +291,14 @@ pub(crate) async fn build_storage(cli: &Cli) -> Result<Option<Arc<dyn StorageBac
                 eprintln!("[storage] SPR: {spr}");
             }
             Ok(Some(Arc::new(backend)))
+        }
+        #[cfg(feature = "shim")]
+        StorageKind::StorageModule => {
+            use logos_messaging_a2a_storage::StorageModuleBackend;
+            let shim = shim.ok_or_else(|| {
+                anyhow::anyhow!("--storage storage-module requires the shim to be available")
+            })?;
+            Ok(Some(Arc::new(StorageModuleBackend::new(shim))))
         }
     }
 }

--- a/crates/logos-messaging-a2a-cli/src/shim.rs
+++ b/crates/logos-messaging-a2a-cli/src/shim.rs
@@ -1,0 +1,38 @@
+//! Per-process LogosAPI shim construction.
+//!
+//! Both `--transport delivery-module` and `--storage storage-module` need
+//! the same `Arc<Shim>`. Boot it once in `main` and pass the handle to
+//! the two builders — that keeps the shim's Qt event-loop thread to a
+//! single-instance and makes both backends share the same LogosAPI
+//! consumer identity in the registry.
+
+use anyhow::{Context, Result};
+use std::sync::Arc;
+
+use logos_core_bindings::Shim;
+
+use crate::cli::{Cli, StorageKind, TransportKind};
+
+/// Whether any selected backend would need the shim. Lets `main` skip
+/// construction (and the noisy Qt-thread spin-up) when neither
+/// shim-based variant is active.
+pub fn cli_needs_shim(cli: &Cli) -> bool {
+    let transport_needs = matches!(cli.transport, TransportKind::DeliveryModule);
+    let storage_needs = matches!(cli.storage, StorageKind::StorageModule);
+    transport_needs || storage_needs
+}
+
+/// Boot the shim. The module name is what the LogosAPI registry shows
+/// for this consumer in logs — using the binary name keeps Basecamp's
+/// own log streams readable when both sides are running.
+pub fn build(_cli: &Cli) -> Result<Arc<Shim>> {
+    if !logos_core_bindings::is_real_build() {
+        anyhow::bail!(
+            "shim backend requested but `logos-core-bindings` was built in stub mode — \
+             rebuild this crate with `LOGOS_CPP_SDK_DIR` pointing at a logos-cpp-sdk checkout"
+        );
+    }
+    let shim = Shim::new("lmao-cli")
+        .with_context(|| "failed to construct LogosAPI shim — is logos-core / Basecamp running?")?;
+    Ok(Arc::new(shim))
+}


### PR DESCRIPTION
## Summary

Fifth step of the issue #19 roll-out — wires the new shim-backed transport (#24) and storage (#23) crates into the CLI so an operator can run:

\`\`\`
lmao agent run --transport delivery-module --storage storage-module ...
\`\`\`

instead of bringing along its own \`liblogosdelivery\` and \`libstorage\` copies. Picks up \`LOGOS_INSTANCE_ID\` from the env, so launching the CLI as a child of \`logoscore\` or Basecamp Just Works.

- New \`shim\` Cargo feature gates \`TransportKind::DeliveryModule\` + \`StorageKind::StorageModule\`. Defaults unchanged on every front.
- \`main\` constructs an \`Arc<Shim>\` **once** when either selected variant needs it, then hands the same handle to both builders so they share one LogosAPI consumer / one Qt event loop.
- \`--delivery-module-cfg <json>\` overrides the cfg passed to \`delivery_module.createNode\`. Default path queries \`getAvailableConfigs()\` and picks the preset matching \`--preset\`.

## What this unblocks

The agent module's \`metadata.json\` can now declare \`storage_module\` + \`delivery_module\` as dependencies and stop bundling its own copies. The companion Basecamp-module-side change lands in a follow-up PR.

## Stacking

Stacked on #24 (DeliveryModuleTransport).

## Test plan

- [x] \`cargo check --workspace\` (no shim feature, what CI sees)
- [x] \`cargo check -p logos-messaging-a2a-cli --features shim\` (stub mode)
- [x] Same with \`LOGOS_CPP_SDK_DIR\` set (real FFI builds)
- [x] \`cargo clippy -p logos-messaging-a2a-cli --features shim --no-deps --tests\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`cargo test -p logos-messaging-a2a-cli --features shim --bin logos-messaging-a2a\` — 95 tests pass
- [ ] End-to-end smoke from inside Basecamp once the agent module's \`metadata.json\` declares its new deps (next PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)