### PR TITLE
fix(shim): smoke-test fallout — LogosResult unwrap + linker deps

### DIFF
--- a/crates/logos-core-bindings/build.rs
+++ b/crates/logos-core-bindings/build.rs
@@ -35,9 +35,6 @@ fn main() {
     for lib in &["Qt6Core", "Qt6Network", "Qt6RemoteObjects"] {
         println!("cargo:rustc-link-lib={lib}");
     }
-    println!("cargo:rustc-link-lib=boost_system");
-    println!("cargo:rustc-link-lib=ssl");
-    println!("cargo:rustc-link-lib=crypto");
     println!("cargo:rustc-link-lib=stdc++");
 
     let bindings = bindgen::Builder::default()

--- a/crates/logos-core-bindings/shim/shim.cpp
+++ b/crates/logos-core-bindings/shim/shim.cpp
@@ -30,6 +30,7 @@
 #include "logos_api_client.h"
 #include "logos_mode.h"
 #include "logos_object.h"
+#include "logos_types.h"
 
 namespace {
 
@@ -86,9 +87,36 @@ char* dup_cstr(const char* s) {
 // QtRO bridge wraps as QString — so the common case is "raw is a
 // QString that's already JSON". Some modules return QVariantMap or
 // QVariantList; convert those via QJsonDocument::fromVariant.
+//
+// As of logos-cpp-sdk's "Abstraction & Refactor part 1" the SDK can
+// also return a `LogosResult` struct ({success, value, error}) — we
+// unwrap that here so callers see the underlying value or a
+// daemon-shape `{"error": "..."}` payload.
 QString variant_to_json(const QVariant& raw) {
     if (!raw.isValid())
         return QStringLiteral("{\"error\":\"invalid response (no method dispatched?)\"}");
+
+    // Unwrap LogosResult before anything else — the inner value goes
+    // through the same conversion path so we get the same JSON shape
+    // as pre-refactor SDKs that returned the bare value. Some modules'
+    // failure paths leave r.error as an invalid QVariant; substitute a
+    // generic message so the caller doesn't see `{"error":""}` which
+    // would otherwise look like a successful empty response.
+    if (raw.canConvert<LogosResult>() &&
+        QString::fromUtf8(raw.typeName()) == QStringLiteral("LogosResult")) {
+        const LogosResult r = raw.value<LogosResult>();
+        if (!r.success) {
+            QString msg = r.error.toString();
+            if (msg.isEmpty()) {
+                msg = QStringLiteral("LogosResult: success=false, error unset");
+            }
+            QJsonObject err;
+            err["error"] = msg;
+            return QString::fromUtf8(
+                QJsonDocument(err).toJson(QJsonDocument::Compact));
+        }
+        return variant_to_json(r.value);
+    }
 
     if (raw.canConvert<QString>()) {
         QString s = raw.toString();

--- a/crates/logos-messaging-a2a-cli/src/main.rs
+++ b/crates/logos-messaging-a2a-cli/src/main.rs
@@ -230,12 +230,25 @@ async fn shim_delivery_cfg_from_preset(
     shim: &logos_core_bindings::Shim,
     preset: &str,
 ) -> Result<String> {
-    // getAvailableConfigs returns a JSON-encoded map { preset: cfgJson, ... }
+    // 60 s timeout: delivery_module's first call after startup can be
+    // slow if the host process is still warming up its QtRO links.
+    // getAvailableConfigs itself is cheap once the wire is open.
     let raw = shim
-        .call("delivery_module", "getAvailableConfigs", "[]", 10_000)
+        .call("delivery_module", "getAvailableConfigs", "[]", 60_000)
         .map_err(|e| anyhow::anyhow!("delivery_module getAvailableConfigs: {e}"))?;
     let map: serde_json::Value = serde_json::from_str(&raw)
-        .map_err(|e| anyhow::anyhow!("getAvailableConfigs returned non-JSON: {e}"))?;
+        .map_err(|e| anyhow::anyhow!("getAvailableConfigs returned non-JSON: {raw}: {e}"))?;
+    // Surface daemon-side error shapes first so the user sees the real
+    // reason (timeout, module-not-loaded, etc.) instead of a wrong-
+    // looking "preset not in catalog" message.
+    if let Some(err) = map.get("error").and_then(serde_json::Value::as_str) {
+        anyhow::bail!("delivery_module getAvailableConfigs: {err}");
+    }
+    if map.get("kind").and_then(serde_json::Value::as_str) == Some("error") {
+        if let Some(msg) = map.get("message").and_then(serde_json::Value::as_str) {
+            anyhow::bail!("delivery_module getAvailableConfigs: {msg}");
+        }
+    }
     // The catalog may arrive as either a {"value": {...}} envelope or
     // a bare map — accept both.
     let catalog = map.get("value").unwrap_or(&map);


### PR DESCRIPTION
## Summary

Three corrections from actually smoke-testing the issue #19 stack against a real Basecamp install (\`logoscore -l delivery_module,storage_module,agent\`, \`LMAO_AGENT_USE_SHIM=1\`):

1. **\`logos-core-bindings/build.rs\`** — drop hard-coded \`-lboost_system\`, \`-lssl\`, \`-lcrypto\`. Vestigial from the Phase-A experiment; the shim itself only uses Qt6 + libstdc++. Without this, building \`lmao --features shim\` outside a Boost-equipped dev shell fails to link.
2. **\`logos-core-bindings/shim/shim.cpp\`** — unwrap \`LogosResult\` in \`variant_to_json\`. The newer logos-cpp-sdk wraps every Q_INVOKABLE return in \`LogosResult{success, value, error}\`; without the unwrap we got back \`{\"error\":\"unsupported response type: LogosResult\"}\`. On failure paths where the module left \`r.error\` invalid, substitute a generic message instead of emitting a deceptively-empty \`{\"error\":\"\"}\`.
3. **\`logos-messaging-a2a-cli/src/main.rs\`** — bump \`getAvailableConfigs\` timeout 10 s → 60 s (rides out the capability-token bootstrap on first-contact). Surface the daemon's \`{\"error\":...}\` and \`{\"kind\":\"error\",\"message\":...}\` shapes explicitly so the operator sees the real reason instead of a wrong-looking \"preset not in catalog\" message.

## What this PR does NOT fix

End-to-end is still not green. \`delivery_module.getAvailableConfigs\` in the installed Basecamp build returns \`LogosResult{success=false, value=invalid, error=invalid}\` — clearly broken on the module side or there's an SDK-version skew between my dev checkout and the SDK it was compiled against. Source-level it returns \`QString\`. Bypass path: plumb \`--delivery-module-cfg <json>\` through \`agent_impl\`'s spawn args. Filing as a separate task.

## Stacking

Stacked on #26 (agent-module shim spawn).

## Test plan

- [x] \`cargo check --workspace\` (stub mode)
- [x] \`cargo check --workspace --features logos-messaging-a2a-cli/shim\` with \`LOGOS_CPP_SDK_DIR\`
- [x] Verified by actual smoke run: this PR removes the previously-blocking error before reaching the still-broken \`getAvailableConfigs\` response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)