### PR TITLE
fix(shim): smoke-test pass — void unwrap + cfg passthrough + createNode timeout

### DIFF
--- a/basecamp/agent-module/src/agent_impl.cpp
+++ b/basecamp/agent-module/src/agent_impl.cpp
@@ -198,6 +198,14 @@ AgentImpl::AgentImpl() : m_state(std::make_shared<State>()) {
         // are owned by delivery_module / storage_module.
         args << "--transport" << "delivery-module"
              << "--storage"   << "storage-module";
+        // Optional explicit delivery_module cfg. Lets the operator
+        // skip the catalog auto-discovery path when it's broken or
+        // when they want a custom mesh config — passes directly to
+        // `delivery_module.createNode(cfg)`.
+        const QString cfg = qEnvironmentVariable("LMAO_AGENT_DELIVERY_CFG");
+        if (!cfg.isEmpty()) {
+            args << "--delivery-module-cfg" << cfg;
+        }
     } else {
         args << "--transport"         << "logos-delivery"
              << "--tcp-port"          << tcpPort

--- a/crates/logos-core-bindings/shim/shim.cpp
+++ b/crates/logos-core-bindings/shim/shim.cpp
@@ -115,6 +115,13 @@ QString variant_to_json(const QVariant& raw) {
             return QString::fromUtf8(
                 QJsonDocument(err).toJson(QJsonDocument::Compact));
         }
+        // Successful LogosResult with an invalid (void/empty) inner
+        // value — the method ran but had nothing to return. Surface
+        // this as a literal `true` so callers expecting a bool result
+        // see a success, and `{"value":true}` parsers also work.
+        if (!r.value.isValid()) {
+            return QStringLiteral("true");
+        }
         return variant_to_json(r.value);
     }
 

--- a/crates/logos-messaging-a2a-transport/src/delivery_module_transport.rs
+++ b/crates/logos-messaging-a2a-transport/src/delivery_module_transport.rs
@@ -46,8 +46,14 @@ use crate::{Result, Transport, TransportError};
 const MODULE: &str = "delivery_module";
 const EVENT_MESSAGE_RECEIVED: &str = "messageReceived";
 
-/// 30 s timeout for normal delivery_module method invocations.
+/// 30 s timeout for normal delivery_module method invocations
+/// (send / subscribe / unsubscribe).
 const SHORT_TIMEOUT_MS: i32 = 30_000;
+/// 120 s timeout for `createNode` + `start` — Waku startup can take
+/// 15-90 s depending on cluster fetch + bootstrap dial latency. The
+/// shim call is synchronous, so the caller's first publish/subscribe
+/// can't fire until this returns.
+const STARTUP_TIMEOUT_MS: i32 = 120_000;
 /// Per-iteration poll timeout for the event-drain task. Short so the
 /// loop reacts promptly to shutdown signals; long enough not to spin.
 const POLL_TIMEOUT_MS: i32 = 250;
@@ -78,12 +84,12 @@ impl DeliveryModuleTransport {
         let setup = tokio::task::spawn_blocking(move || -> Result<()> {
             let create_args = serde_json::to_string(&serde_json::json!([cfg_owned]))
                 .map_err(|e| TransportError::Transport(format!("createNode args: {e}")))?;
-            let resp = call(&backend, "createNode", &create_args, SHORT_TIMEOUT_MS)?;
+            let resp = call(&backend, "createNode", &create_args, STARTUP_TIMEOUT_MS)?;
             // delivery_module's createNode returns a plain `bool` —
             // serialised as either `true` or an error object.
             check_bool(&resp, "createNode")?;
 
-            let resp = call(&backend, "start", "[]", SHORT_TIMEOUT_MS)?;
+            let resp = call(&backend, "start", "[]", STARTUP_TIMEOUT_MS)?;
             check_bool(&resp, "start")?;
 
             backend


### PR DESCRIPTION
## Summary

End-to-end smoke is now green. Three small follow-ups from the round-1 smoke fixes (#27):

- **\`shim/shim.cpp\`**: when \`LogosResult\` unwraps to \`success=true, value=invalid\`, return a literal \`true\` instead of \"invalid response\". The SDK packs bool / void returns this way (bool value gets dropped in some paths); callers who do \`check_bool\` now see a success.
- **\`delivery_module_transport.rs\`**: split a new 120 s \`STARTUP_TIMEOUT_MS\` for \`createNode\` + \`start\` from the existing 30 s for send/subscribe/unsubscribe. Cold-start Waku (cluster fetch + bootstrap dial) routinely takes 15-90 s.
- **\`basecamp/agent-module/src/agent_impl.cpp\`**: pipe \`LMAO_AGENT_DELIVERY_CFG\` → \`--delivery-module-cfg\`. Lets the operator skip the still-broken \`getAvailableConfigs\` auto-discovery and pass the createNode JSON directly.

## Verified

\`\`\`
LMAO_AGENT_USE_SHIM=1 \\
LMAO_AGENT_DELIVERY_CFG='{\"logLevel\":\"WARN\",\"mode\":\"Core\",\"preset\":\"logos.dev\"}' \\
logoscore -l delivery_module,storage_module,agent -c \"agent.info()\" --quit-on-finish
\`\`\`

returns:

\`\`\`json
{\"kind\":\"info\",\"name\":\"basecamp\",\"pubkey\":\"036174d7bda3…\",
 \"capabilities\":[\"text\"],\"uptime_secs\":169,
 \"socket_path\":\"/run/user/1000/lmao-basecamp-...\",
 \"storage_enabled\":true,
 \"encryption_pubkey\":\"cd9de6e0…\",
 \"load\":{\"bucket\":\"free\",\"queue_depth\":0,\"max_concurrent\":1}}
\`\`\`

— delivery_module owns Waku, storage_module owns Codex, agent's spawned \`lmao\` has zero embedded libs. The smoke had no peer fleet (expected \"no subscribed peers\" warnings); the *identity / IPC / storage* path is fully wired through the shim.

## Test plan

- [x] \`cargo check --workspace\` (stub mode)
- [x] \`cargo test -p logos-messaging-a2a-transport --features delivery-module --lib delivery_module_transport\` — 11 unit tests pass
- [x] \`cargo fmt --check\` clean
- [x] End-to-end \`agent.info()\` through the shim path, full Basecamp setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)